### PR TITLE
Sliced files

### DIFF
--- a/Reader/Reader.php
+++ b/Reader/Reader.php
@@ -226,7 +226,7 @@ class Reader
         $part = 0;
         foreach ($manifest->entries as $slice) {
             $sliceInfo = $fileInfo;
-            $sliceDestination = $destination . "/" . $fileInfo["id"] . '_' . $fileInfo["name"] . "." . $part++;
+            $sliceDestination = $destination . "/part." . $part++;
 
             $sliceInfo["s3Path"]["key"] = str_replace("s3://" . $fileInfo["s3Path"]["bucket"] . "/", "", $slice->url);
             $this->downloadFile($sliceInfo, $sliceDestination);

--- a/Tests/ReaderFilesTest.php
+++ b/Tests/ReaderFilesTest.php
@@ -217,8 +217,8 @@ class ReaderFilesTest extends \PHPUnit_Framework_TestCase
         $fileName = $fileId . "_in.c-docker-test-redshift.test_file.csv";
         self::assertEquals(
             '"test","test"' . "\n",
-            file_get_contents($dlDir . "/" . $fileName . "/" . $fileName . ".0")
-            . file_get_contents($dlDir . "/" . $fileName . "/" . $fileName . ".1")
+            file_get_contents($dlDir . "/" . $fileName . "/part.0")
+            . file_get_contents($dlDir . "/" . $fileName . "/part.1")
         );
 
         $manifestFile = $dlDir . "/" . $fileName . ".manifest";

--- a/Tests/ReaderTablesDefaultTest.php
+++ b/Tests/ReaderTablesDefaultTest.php
@@ -55,8 +55,8 @@ class ReaderTablesDefaultTest extends ReaderTablesTestAbstract
         $configuration = [
             [
                 "source" => "in.c-docker-test.empty",
-                "destination" => "empty.csv"
-            ]
+                "destination" => "empty.csv",
+            ],
         ];
 
         $reader->downloadTables($configuration, $this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . "download");


### PR DESCRIPTION
fix: workaround bug https://github.com/keboola/connection/issues/1429
fix: download sliced files into a subdirectory
fix: make sliced subdirectory always present, fixes #19