### PR TITLE
fix: double default

### DIFF
--- a/Configuration/File.php
+++ b/Configuration/File.php
@@ -24,7 +24,7 @@ class File extends Configuration
                 ->end()
                 ->scalarNode("query")->end()
                 ->booleanNode("filter_by_run_id")->end()
-                ->integerNode("limit")->defaultValue(10)->end()
+                ->integerNode("limit")->end()
                 ->arrayNode("processed_tags")
                     ->prototype("scalar")->end()
                 ->end()


### PR DESCRIPTION
follow up to https://github.com/keboola/input-mapping/pull/40

the default is doubled in the configuration and in the code, the default limit in the code is more aggressive - converts 0 to the default (i.e. it's possible to have no limit). Therefore i kept the default in the code.