### PR TITLE
PS-330: Support ABS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 script:
   - ./vendor/bin/phpcs --standard=psr2 --ignore=vendor -n .
   - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+  - export STORAGE_API_TOKEN=$STORAGE_API_TOKEN_ABS; ./vendor/bin/phpunit
 
 after_success:
   - ./vendor/bin/test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 script:
   - ./vendor/bin/phpcs --standard=psr2 --ignore=vendor -n .
   - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-  - export STORAGE_API_TOKEN=$STORAGE_API_TOKEN_ABS; ./vendor/bin/phpunit
+  - export STORAGE_API_TOKEN=$STORAGE_API_TOKEN_ABS; ./vendor/bin/phpunit --testsuite Common
 
 after_success:
   - ./vendor/bin/test-reporter

--- a/Reader/Reader.php
+++ b/Reader/Reader.php
@@ -111,8 +111,7 @@ class Reader
                 $fileDestinationPath = sprintf('%s/%s_%s', $destination, $fileInfo['id'], $fileInfo["name"]);
                 $this->logger->info(sprintf('Fetching file %s (%s).', $fileInfo['name'], $file['id']));
                 try {
-                    $storageClient->downloadFile($file['id'], $fileDestinationPath);
-                    $this->writeFileManifest($fileInfo, $fileDestinationPath . ".manifest");
+                    $this->downloadFile($fileInfo, $fileDestinationPath);
                 } catch (\Exception $e) {
                     throw new InputOperationException(
                         sprintf('Failed to download file %s (%s).', $fileInfo['name'], $file['id']),
@@ -184,6 +183,22 @@ class Reader
                 $e
             );
         }
+    }
+
+    /**
+     * @param array $fileInfo array file info from Storage API
+     * @param string $fileDestinationPath string Destination file path
+     * @throws \Exception
+     */
+    protected function downloadFile($fileInfo, $fileDestinationPath)
+    {
+        if ($fileInfo['isSliced']) {
+            $this->getClient()->downloadSlicedFile($fileInfo['id'], $fileDestinationPath);
+        } else {
+            $this->getClient()->downloadFile($fileInfo['id'], $fileDestinationPath);
+        }
+
+        $this->writeFileManifest($fileInfo, $fileDestinationPath . ".manifest");
     }
 
     /**

--- a/Reader/Reader.php
+++ b/Reader/Reader.php
@@ -2,7 +2,6 @@
 
 namespace Keboola\InputMapping\Reader;
 
-use Aws\S3\S3Client;
 use Keboola\InputMapping\Configuration\File\Manifest\Adapter as FileAdapter;
 use Keboola\InputMapping\Configuration\Table\Manifest\Adapter as TableAdapter;
 use Keboola\InputMapping\Exception\InputOperationException;
@@ -15,11 +14,9 @@ use Keboola\StorageApi\Metadata;
 use Keboola\StorageApi\Options\GetFileOptions;
 use Keboola\StorageApi\Options\ListFilesOptions;
 use Keboola\StorageApi\TableExporter;
-use Keboola\StorageApi\HandlerStack;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Filesystem\Filesystem;
-use GuzzleHttp\Client as HttpClient;
 
 class Reader
 {

--- a/Tests/Reader/DownloadFilesRedshiftTest.php
+++ b/Tests/Reader/DownloadFilesRedshiftTest.php
@@ -59,30 +59,4 @@ class DownloadFilesRedshiftTest extends DownloadFilesTestAbstract
         self::assertArrayHasKey('is_sliced', $manifest);
         self::assertTrue($manifest['is_sliced']);
     }
-
-    public function testReadFilesEmptySlices()
-    {
-        $fileUploadOptions = new FileUploadOptions();
-        $fileUploadOptions
-            ->setIsSliced(true)
-            ->setFileName('empty_file');
-        $uploadFileId = $this->client->uploadSlicedFile([], $fileUploadOptions);
-        sleep(2);
-
-        $reader = new Reader($this->client, new NullLogger());
-        $configuration = [
-            [
-                'query' => 'id:' . $uploadFileId,
-            ],
-        ];
-        $reader->downloadFiles($configuration, $this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'download');
-
-        $adapter = new Adapter();
-        $manifest = $adapter->readFromFile(
-            $this->temp->getTmpFolder() . '/download/' . $uploadFileId . '_empty_file.manifest'
-        );
-        self::assertEquals($uploadFileId, $manifest['id']);
-        self::assertEquals('empty_file', $manifest['name']);
-        self::assertDirectoryExists($this->temp->getTmpFolder() . '/download/' . $uploadFileId . '_empty_file');
-    }
 }

--- a/Tests/Reader/DownloadFilesTest.php
+++ b/Tests/Reader/DownloadFilesTest.php
@@ -3,10 +3,8 @@
 namespace Keboola\InputMapping\Tests\Reader;
 
 use Keboola\InputMapping\Configuration\File\Manifest\Adapter;
-use Keboola\InputMapping\Exception\InputOperationException;
 use Keboola\InputMapping\Exception\InvalidInputException;
 use Keboola\InputMapping\Reader\Reader;
-use Keboola\StorageApi\Client;
 use Keboola\StorageApi\Options\FileUploadOptions;
 use Psr\Log\NullLogger;
 use Symfony\Component\Finder\Finder;

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/yaml": "^2.8|^4.1",
         "symfony/finder": "^2.8|^4.1",
         "symfony/serializer": "^2.8|^4.1",
-        "keboola/storage-api-client": "^10.0",
+        "keboola/storage-api-client": "^10.12",
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-
 version: "2"
 services:
   # for development purposes


### PR DESCRIPTION
Depends on #49 

- use `downloadFile` and `downloadSlicedFile` methods from Storage Client
- removed `testReadFilesRegion` as it didn't make sense anymore
- slices of sliced files are now in little different format: 
  - before `/part.0, /part.1` 
  - now `/csv0000_part_00, csv0000_part_01`
  - I've modified the test, but I'm not sure if it doesn't affect some other functionality