### PR TITLE
PS-330: Divide tests into suites by backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 script:
   - ./vendor/bin/phpcs --standard=psr2 --ignore=vendor -n .
   - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+  - export STORAGE_API_TOKEN=$STORAGE_API_TOKEN_ABS; ./vendor/bin/phpunit --testsuite Common
 
 after_success:
   - ./vendor/bin/test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ install:
 script:
   - ./vendor/bin/phpcs --standard=psr2 --ignore=vendor -n .
   - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-  - export STORAGE_API_TOKEN=$STORAGE_API_TOKEN_ABS; ./vendor/bin/phpunit --testsuite Common
 
 after_success:
   - ./vendor/bin/test-reporter

--- a/Tests/Reader/DownloadFilesRedshiftTest.php
+++ b/Tests/Reader/DownloadFilesRedshiftTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Keboola\InputMapping\Tests\Reader;
+
+use Keboola\Csv\CsvFile;
+use Keboola\InputMapping\Configuration\File\Manifest\Adapter;
+use Keboola\InputMapping\Exception\InputOperationException;
+use Keboola\InputMapping\Exception\InvalidInputException;
+use Keboola\InputMapping\Reader\Reader;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\Options\FileUploadOptions;
+use Keboola\StorageApi\Options\GetFileOptions;
+use Keboola\StorageApi\Options\ListFilesOptions;
+use Keboola\Temp\Temp;
+use Psr\Log\NullLogger;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+class DownloadFilesRedshiftTest extends DownloadFilesTestAbstract
+{
+    public function testReadSlicedFile()
+    {
+        // Create bucket
+        if (!$this->client->bucketExists("in.c-docker-test-redshift")) {
+            $this->client->createBucket("docker-test-redshift", Client::STAGE_IN, "Docker Testsuite", "redshift");
+        }
+
+        // Create redshift table and export it to produce a sliced file
+        if (!$this->client->tableExists("in.c-docker-test-redshift.test_file")) {
+            $csv = new CsvFile($this->tmpDir . "/upload.csv");
+            $csv->writeRow(["Id", "Name"]);
+            $csv->writeRow(["test", "test"]);
+            $this->client->createTableAsync("in.c-docker-test-redshift", "test_file", $csv);
+        }
+        $table = $this->client->exportTableAsync('in.c-docker-test-redshift.test_file');
+        $fileId = $table['file']['id'];
+
+        $reader = new Reader($this->client, new NullLogger());
+        $configuration = [['query' => 'id: ' . $fileId]];
+
+        $dlDir = $this->tmpDir . "/download";
+        $reader->downloadFiles($configuration, $dlDir);
+        $fileName = $fileId . "_in.c-docker-test-redshift.test_file.csv";
+
+        $resultFileContent = '';
+        $finder = new Finder();
+
+        /** @var \SplFileInfo $file */
+        foreach ($finder->files()->in($dlDir . '/' . $fileName) as $file) {
+            $resultFileContent .= file_get_contents($file->getPathname());
+        }
+
+        self::assertEquals('"test","test"' . "\n", $resultFileContent);
+
+        $manifestFile = $dlDir . "/" . $fileName . ".manifest";
+        self::assertFileExists($manifestFile);
+        $adapter = new Adapter();
+        $manifest = $adapter->readFromFile($manifestFile);
+        self::assertArrayHasKey('is_sliced', $manifest);
+        self::assertTrue($manifest['is_sliced']);
+    }
+
+    public function testReadFilesEmptySlices()
+    {
+        $fileUploadOptions = new FileUploadOptions();
+        $fileUploadOptions
+            ->setIsSliced(true)
+            ->setFileName('empty_file');
+        $uploadFileId = $this->client->uploadSlicedFile([], $fileUploadOptions);
+        sleep(2);
+
+        $reader = new Reader($this->client, new NullLogger());
+        $configuration = [
+            [
+                'query' => 'id:' . $uploadFileId,
+            ],
+        ];
+        $reader->downloadFiles($configuration, $this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'download');
+
+        $adapter = new Adapter();
+        $manifest = $adapter->readFromFile(
+            $this->temp->getTmpFolder() . '/download/' . $uploadFileId . '_empty_file.manifest'
+        );
+        self::assertEquals($uploadFileId, $manifest['id']);
+        self::assertEquals('empty_file', $manifest['name']);
+        self::assertDirectoryExists($this->temp->getTmpFolder() . '/download/' . $uploadFileId . '_empty_file');
+    }
+}

--- a/Tests/Reader/DownloadFilesTestAbstract.php
+++ b/Tests/Reader/DownloadFilesTestAbstract.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Keboola\InputMapping\Tests\Reader;
+
+use Keboola\InputMapping\Configuration\File\Manifest\Adapter;
+use Keboola\InputMapping\Exception\InvalidInputException;
+use Keboola\InputMapping\Reader\Reader;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\Options\FileUploadOptions;
+use Keboola\StorageApi\Options\ListFilesOptions;
+use Keboola\Temp\Temp;
+use Psr\Log\NullLogger;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+class DownloadFilesTestAbstract extends \PHPUnit_Framework_TestCase
+{
+    /** @var Client */
+    protected $client;
+
+    /** @var string */
+    protected $tmpDir;
+
+    /** @var Temp */
+    protected $temp;
+
+    public function setUp()
+    {
+        // Create folders
+        $temp = new Temp('docker');
+        $temp->initRunFolder();
+        $this->temp = $temp;
+        $this->tmpDir = $temp->getTmpFolder();
+        $fs = new Filesystem();
+        $fs->mkdir($this->tmpDir . "/download");
+        $this->client = new Client(["token" => STORAGE_API_TOKEN, "url" => STORAGE_API_URL]);
+    }
+
+    public function tearDown()
+    {
+        // Delete local files
+        $finder = new Finder();
+        $fs = new Filesystem();
+        $fs->remove($finder->files()->in($this->tmpDir . "/download"));
+        $fs->remove($finder->files()->in($this->tmpDir));
+        $fs->remove($this->tmpDir . "/download");
+        $fs->remove($this->tmpDir);
+
+        // Delete file uploads
+        $options = new ListFilesOptions();
+        $options->setTags(["docker-bundle-test"]);
+        $files = $this->client->listFiles($options);
+        foreach ($files as $file) {
+            $this->client->deleteFile($file["id"]);
+        }
+    }
+}

--- a/Tests/Reader/DownloadFilesTestAbstract.php
+++ b/Tests/Reader/DownloadFilesTestAbstract.php
@@ -2,14 +2,9 @@
 
 namespace Keboola\InputMapping\Tests\Reader;
 
-use Keboola\InputMapping\Configuration\File\Manifest\Adapter;
-use Keboola\InputMapping\Exception\InvalidInputException;
-use Keboola\InputMapping\Reader\Reader;
 use Keboola\StorageApi\Client;
-use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\StorageApi\Options\ListFilesOptions;
 use Keboola\Temp\Temp;
-use Psr\Log\NullLogger;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 

--- a/Tests/Reader/DownloadTablesS3DefaultTest.php
+++ b/Tests/Reader/DownloadTablesS3DefaultTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Keboola\InputMapping\Tests\Reader;
+
+use Keboola\Csv\CsvFile;
+use Keboola\InputMapping\Configuration\Table\Manifest\Adapter;
+use Keboola\InputMapping\Exception\InvalidInputException;
+use Keboola\InputMapping\Reader\Options\InputTableOptionsList;
+use Keboola\InputMapping\Reader\Reader;
+use Keboola\InputMapping\Reader\State\InputTableStateList;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
+use Keboola\StorageApi\Metadata;
+use Keboola\StorageApi\Options\FileUploadOptions;
+use Psr\Log\NullLogger;
+use Psr\Log\Test\TestLogger;
+
+class DownloadTablesS3DefaultTest extends DownloadTablesTestAbstract
+{
+    public function setUp()
+    {
+        parent::setUp();
+        try {
+            $this->client->dropBucket("in.c-docker-test", ["force" => true]);
+        } catch (ClientException $e) {
+            if ($e->getCode() != 404) {
+                throw $e;
+            }
+        }
+        $this->client->createBucket("docker-test", Client::STAGE_IN, "Docker Testsuite");
+
+        // Create table
+        $csv = new CsvFile($this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . "upload.csv");
+        $csv->writeRow(["Id", "Name", "foo", "bar"]);
+        $csv->writeRow(["id1", "name1", "foo1", "bar1"]);
+        $csv->writeRow(["id2", "name2", "foo2", "bar2"]);
+        $csv->writeRow(["id3", "name3", "foo3", "bar3"]);
+        $this->client->createTableAsync("in.c-docker-test", "test", $csv);
+        $this->client->createTableAsync("in.c-docker-test", "test2", $csv);
+    }
+
+    public function testReadTablesS3DefaultBackend()
+    {
+        $logger = new TestLogger();
+        $reader = new Reader($this->client, $logger);
+        $configuration = new InputTableOptionsList([
+            [
+                "source" => "in.c-docker-test.test",
+                "destination" => "test.csv",
+            ],
+            [
+                "source" => "in.c-docker-test.test2",
+                "destination" => "test2.csv",
+            ]
+        ]);
+
+        $reader->downloadTables(
+            $configuration,
+            new InputTableStateList([]),
+            $this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . "download",
+            "s3"
+        );
+
+        $adapter = new Adapter();
+
+        $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . "/download/test.csv.manifest");
+        self::assertEquals("in.c-docker-test.test", $manifest["id"]);
+        $this->assertS3info($manifest);
+
+        $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . "/download/test2.csv.manifest");
+        self::assertEquals("in.c-docker-test.test2", $manifest["id"]);
+        $this->assertS3info($manifest);
+        self::assertTrue($logger->hasInfoThatContains('Processing 2 S3 table exports.'));
+    }
+}

--- a/Tests/Reader/DownloadTablesTestAbstract.php
+++ b/Tests/Reader/DownloadTablesTestAbstract.php
@@ -8,15 +8,20 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class DownloadTablesTestAbstract extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var Client
-     */
+    /** @var Client */
     protected $client;
 
-    /**
-     * @var Temp
-     */
+    /** @var Temp */
     protected $temp;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->temp = new Temp('docker');
+        $fs = new Filesystem();
+        $fs->mkdir($this->temp->getTmpFolder() . "/download");
+        $this->client = new Client(["token" => STORAGE_API_TOKEN, "url" => STORAGE_API_URL]);
+    }
 
     /**
      * @param array $manifest
@@ -58,14 +63,5 @@ class DownloadTablesTestAbstract extends \PHPUnit_Framework_TestCase
         for ($i = 1; $i < count($expectedArray); $i++) {
             self::assertTrue(in_array($expectedArray[$i], $actualArrayWithoutHeader));
         }
-    }
-
-    public function setUp()
-    {
-        parent::setUp();
-        $this->temp = new Temp('docker');
-        $fs = new Filesystem();
-        $fs->mkdir($this->temp->getTmpFolder() . "/download");
-        $this->client = new Client(["token" => STORAGE_API_TOKEN, "url" => STORAGE_API_URL]);
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,9 +10,26 @@
          syntaxCheck="false"
          bootstrap="bootstrap.php">
 
-    <testsuite name="Test Suite">
-        <directory>Tests</directory>
-    </testsuite>
+    <testsuites>
+        <testsuite name="Common">
+            <directory>Tests/Configuration</directory>
+            <directory>Tests/Keboola</directory>
+            <directory>Tests/Reader/Options</directory>
+            <file>Tests/Reader/DownloadFilesTest.php</file>
+            <file>Tests/Reader/DownloadTablesAdaptiveTest.php</file>
+            <file>Tests/Reader/DownloadTablesDefaultTest.php</file>
+            <file>Tests/Reader/DownloadTablesOutputStateTest.php</file>
+            <file>Tests/Reader/ReaderTest.php</file>
+            <file>Tests/Reader/TableDefinitionResolverTest.php</file>
+        </testsuite>
+        <testsuite name="Redshift">
+            <file>Tests/Reader/DownloadFilesRedshiftTest.php</file>
+            <file>Tests/Reader/DownloadTablesRedshiftTest.php</file>
+        </testsuite>
+        <testsuite name="S3">
+            <file>Tests/Reader/DownloadTablesS3DefaultTest.php</file>
+        </testsuite>
+    </testsuites>
 
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">


### PR DESCRIPTION
Testy rozdelene zhruba podla backendov.
- Common suite - testy ktore funuguju s kazdym backendom a kazdym file storageom
- Redshift suite - testy pre Redshift backend, nefunguju s ABS file storageom
- S3 suite - jeden test pre "Default" backend s S3 storageom => nefunguje s ABS file storageom

ABS testy sa spustia s tokenom, ktory ma pristup do projektu, kde je zapnuty ABS file storage. Spusti sa len "Common" test suite.

Viz https://keboola.slack.com/archives/CQB468K63/p1583769947009200