### PR TITLE
refactor: download tables split to separate strategy classes

### DIFF
--- a/Reader/LoadTypeDecider.php
+++ b/Reader/LoadTypeDecider.php
@@ -6,7 +6,7 @@ class LoadTypeDecider
 {
     public static function canClone(array $tableInfo, $workspaceType, array $exportOptions)
     {
-        if ($exportOptions || ($tableInfo['bucket']['backend'] !== $workspaceType)) {
+        if ($exportOptions || ($tableInfo['bucket']['backend'] !== $workspaceType) || ($workspaceType !== 'snowflake')) {
             return false;
         }
         return true;

--- a/Reader/ManifestWriter.php
+++ b/Reader/ManifestWriter.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Keboola\InputMapping\Reader;
+
+use Keboola\InputMapping\Configuration\File\Manifest\Adapter as FileAdapter;
+use Keboola\InputMapping\Configuration\Table\Manifest\Adapter as TableAdapter;
+use Keboola\InputMapping\Exception\InputOperationException;
+use Keboola\InputMapping\Exception\InvalidInputException;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\Metadata;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+class ManifestWriter
+{
+    /** @var Client */
+    protected $storageClient;
+
+    /** @var string */
+    protected $format = 'json';
+
+    public function __construct(Client $storageClient, $format)
+    {
+        $this->storageClient = $storageClient;
+        $this->format = $format;
+    }
+
+    /**
+     * @param array $tableInfo
+     * @param string $destination
+     * @param array $columns
+     */
+    public function writeTableManifest($tableInfo, $destination, $columns)
+    {
+        $manifest = [
+            "id" => $tableInfo["id"],
+            "uri" => $tableInfo["uri"],
+            "name" => $tableInfo["name"],
+            "primary_key" => $tableInfo["primaryKey"],
+            "created" => $tableInfo["created"],
+            "last_change_date" => $tableInfo["lastChangeDate"],
+            "last_import_date" => $tableInfo["lastImportDate"],
+        ];
+        if (isset($tableInfo["s3"])) {
+            $manifest["s3"] = $tableInfo["s3"];
+        }
+        if (!$columns) {
+            $columns = $tableInfo["columns"];
+        }
+        $manifest["columns"] = $columns;
+
+        $metadata = new Metadata($this->storageClient);
+        $manifest['metadata'] = $metadata->listTableMetadata($tableInfo['id']);
+        $manifest['column_metadata'] = [];
+        foreach ($columns as $column) {
+            $manifest['column_metadata'][$column] = $metadata->listColumnMetadata($tableInfo['id'] . '.' . $column);
+        }
+        $adapter = new TableAdapter($this->format);
+        try {
+            $adapter->setConfig($manifest);
+            $adapter->writeToFile($destination);
+        } catch (InvalidInputException $e) {
+            throw new InputOperationException(
+                "Failed to write manifest for table {$tableInfo['id']} - {$tableInfo['name']}.",
+                $e
+            );
+        }
+    }
+
+    /**
+     * @param $fileInfo
+     * @param $destination
+     * @throws \Exception
+     */
+    public function writeFileManifest($fileInfo, $destination)
+    {
+        $manifest = [
+            "id" => $fileInfo["id"],
+            "name" => $fileInfo["name"],
+            "created" => $fileInfo["created"],
+            "is_public" => $fileInfo["isPublic"],
+            "is_encrypted" => $fileInfo["isEncrypted"],
+            "is_sliced" => $fileInfo["isSliced"],
+            "tags" => $fileInfo["tags"],
+            "max_age_days" => $fileInfo["maxAgeDays"],
+            "size_bytes" => intval($fileInfo["sizeBytes"])
+        ];
+
+        $adapter = new FileAdapter($this->format);
+        try {
+            $adapter->setConfig($manifest);
+            $adapter->writeToFile($destination);
+        } catch (InvalidConfigurationException $e) {
+            throw new InputOperationException(
+                "Failed to write manifest for file {$fileInfo['id']} - {$fileInfo['name']}.",
+                0,
+                $e
+            );
+        }
+    }
+}

--- a/Reader/Strategy/AbstractStrategy.php
+++ b/Reader/Strategy/AbstractStrategy.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Keboola\InputMapping\Reader\Strategy;
+
+use Keboola\InputMapping\Reader\ManifestWriter;
+use Keboola\InputMapping\Reader\Options\InputTableOptions;
+use Keboola\InputMapping\Reader\State\InputTableStateList;
+use Keboola\InputMapping\Reader\WorkspaceProviderInterface;
+use Keboola\StorageApi\Client;
+use Psr\Log\LoggerInterface;
+
+abstract class AbstractStrategy implements StrategyInterface
+{
+    /** @var Client */
+    protected $storageClient;
+
+    /** LoggerInterface */
+    protected $logger;
+
+    /** @var WorkspaceProviderInterface */
+    protected $workspaceProvider;
+
+    /** @var InputTableStateList */
+    protected $tablesState;
+
+    /** string */
+    protected $destination;
+
+    /** @var ManifestWriter */
+    protected $manifestWriter;
+
+    public function __construct(
+        Client $storageClient,
+        LoggerInterface $logger,
+        WorkspaceProviderInterface $workspaceProvider,
+        InputTableStateList $tablesState,
+        $destination,
+        $format = 'json'
+    ) {
+        $this->storageClient = $storageClient;
+        $this->logger = $logger;
+        $this->workspaceProvider = $workspaceProvider;
+        $this->tablesState = $tablesState;
+        $this->destination = $destination;
+        $this->manifestWriter = new ManifestWriter($this->storageClient, $format);
+    }
+
+    /**
+     * @param InputTableOptions[]
+     * @return InputTableStateList
+     */
+    public function downloadTables($tables)
+    {
+        $outputStateConfiguration = [];
+        $exports = [];
+        /** @var InputTableOptions $table */
+        foreach ($tables as $table) {
+            $tableInfo = $this->storageClient->getTable($table->getSource());
+            $outputStateConfiguration[] = [
+                'source' => $table->getSource(),
+                'lastImportDate' => $tableInfo['lastImportDate']
+            ];
+            $exports[] = $this->downloadTable($table);
+            $this->logger->info("Fetched table " . $table->getSource() . ".");
+        }
+
+        $this->handleExports($exports);
+
+        $this->logger->info("All tables were fetched.");
+
+        return new InputTableStateList($outputStateConfiguration);
+    }
+
+    /**
+     * @param string $destination
+     * @param InputTableOptions $table
+     * @return string
+     */
+    protected function getDestinationFilePath($destination, InputTableOptions $table)
+    {
+        if (!$table->getDestination()) {
+            return $destination . "/" . $table->getSource();
+        } else {
+            return $destination . "/" . $table->getDestination();
+        }
+    }
+}

--- a/Reader/Strategy/LocalStrategy.php
+++ b/Reader/Strategy/LocalStrategy.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Keboola\InputMapping\Reader\Strategy;
+
+use Keboola\InputMapping\Exception\InvalidInputException;
+use Keboola\InputMapping\Reader\Options\InputTableOptions;
+use Keboola\StorageApi\TableExporter;
+
+class LocalStrategy extends AbstractStrategy
+{
+    const DEFAULT_MAX_EXPORT_SIZE_BYTES = 100000000000;
+    const EXPORT_SIZE_LIMIT_NAME = 'components.max_export_size_bytes';
+
+    public function downloadTable(InputTableOptions $table)
+    {
+        $tokenInfo = $this->storageClient->verifyToken();
+        $exportLimit = self::DEFAULT_MAX_EXPORT_SIZE_BYTES;
+        if (!empty($tokenInfo['owner']['limits'][self::EXPORT_SIZE_LIMIT_NAME])) {
+            $exportLimit = $tokenInfo['owner']['limits'][self::EXPORT_SIZE_LIMIT_NAME]['value'];
+        }
+
+        $file = $this->getDestinationFilePath($this->destination, $table);
+        $tableInfo = $this->storageClient->getTable($table->getSource());
+        if ($tableInfo['dataSizeBytes'] > $exportLimit) {
+            throw new InvalidInputException(sprintf(
+                'Table "%s" with size %s bytes exceeds the input mapping limit of %s bytes. ' .
+                'Please contact support to raise this limit',
+                $table->getSource(),
+                $tableInfo['dataSizeBytes'],
+                $exportLimit
+            ));
+        }
+
+        $this->manifestWriter->writeTableManifest($tableInfo, $file . ".manifest", $table->getColumns());
+
+        return [
+            "tableId" => $table->getSource(),
+            "destination" => $file,
+            "exportOptions" => $table->getStorageApiExportOptions($this->tablesState),
+        ];
+    }
+
+    public function handleExports($exports)
+    {
+        $tableExporter = new TableExporter($this->storageClient);
+        $this->logger->info("Processing " . count($exports) . " local table exports.");
+        $tableExporter->exportTables($exports);
+    }
+}

--- a/Reader/Strategy/RedshiftStrategy.php
+++ b/Reader/Strategy/RedshiftStrategy.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Keboola\InputMapping\Reader\Strategy;
+
+use Keboola\InputMapping\Reader\LoadTypeDecider;
+use Keboola\InputMapping\Reader\Options\InputTableOptions;
+use Keboola\InputMapping\Reader\WorkspaceProviderInterface;
+
+class RedshiftStrategy extends AbstractStrategy
+{
+    private $workspaceProviderId = WorkspaceProviderInterface::TYPE_REDSHIFT;
+
+    public function downloadTable(InputTableOptions $table)
+    {
+        $tableInfo = $this->storageClient->getTable($table->getSource());
+        $loadOptions = $table->getStorageApiLoadOptions($this->tablesState);
+        if (LoadTypeDecider::canClone($tableInfo, 'redshift', $loadOptions)) {
+            $this->logger->info(sprintf('Table "%s" will be cloned.', $table->getSource()));
+            return [
+                'table' => $table,
+                'type' => 'clone'
+            ];
+        }
+        $this->logger->info(sprintf('Table "%s" will be copied.', $table->getSource()));
+        return [
+            'table' => [$table, $loadOptions],
+            'type' => 'copy',
+        ];
+    }
+
+    public function handleExports($exports)
+    {
+        $cloneInputs = [];
+        $copyInputs = [];
+
+        foreach ($exports as $export) {
+            if ($export['type'] === 'clone') {
+                /** @var InputTableOptions $table */
+                $table = $export['table'];
+                $cloneInputs[] = [
+                    'source' => $table->getSource(),
+                    'destination' => $table->getDestination()
+                ];
+                $workspaceTables[] = $table;
+            }
+            if ($export['type'] === 'copy') {
+                list ($table, $exportOptions) = $export['table'];
+                $copyInputs[] = array_merge(
+                    [
+                        'source' => $table->getSource(),
+                        'destination' => $table->getDestination(),
+                    ],
+                    $exportOptions
+                );
+                $workspaceTables[] = $table;
+            }
+        }
+
+        $this->logger->info(
+            sprintf('Cloning %s tables to %s workspace.', count($cloneInputs), $this->workspaceProviderId)
+        );
+        $job = $this->storageClient->apiPost(
+            'storage/workspaces/' . $this->workspaceProvider->getWorkspaceId($this->workspaceProviderId) . '/load-clone',
+            [
+                'input' => $cloneInputs,
+                'preserve' => 1,
+            ],
+            false
+        );
+        $workspaceJobs[] = $job['id'];
+
+        $this->logger->info(
+            sprintf('Copying %s tables to %s workspace.', count($copyInputs), $this->workspaceProviderId)
+        );
+        $job = $this->storageClient->apiPost(
+            'storage/workspaces/' . $this->workspaceProvider->getWorkspaceId($this->workspaceProviderId) . '/load',
+            [
+                'input' => $copyInputs,
+                'preserve' => 1,
+            ],
+            false
+        );
+        $workspaceJobs[] = $job['id'];
+
+
+        $workspaceJobs = [];
+        $workspaceTables = [];
+
+        if ($workspaceJobs) {
+            $this->logger->info('Processing ' . count($workspaceJobs) . ' workspace exports.');
+            $this->storageClient->handleAsyncTasks($workspaceJobs);
+            foreach ($workspaceTables as $table) {
+                $manifestPath = $this->getDestinationFilePath($this->destination, $table) . ".manifest";
+                $tableInfo = $this->storageClient->getTable($table->getSource());
+                $this->manifestWriter->writeTableManifest($tableInfo, $manifestPath, $table->getColumns());
+            }
+        }
+    }
+}

--- a/Reader/Strategy/RedshiftStrategy.php
+++ b/Reader/Strategy/RedshiftStrategy.php
@@ -8,7 +8,7 @@ use Keboola\InputMapping\Reader\WorkspaceProviderInterface;
 
 class RedshiftStrategy extends AbstractStrategy
 {
-    private $workspaceProviderId = WorkspaceProviderInterface::TYPE_REDSHIFT;
+    protected $workspaceProviderId = WorkspaceProviderInterface::TYPE_REDSHIFT;
 
     public function downloadTable(InputTableOptions $table)
     {

--- a/Reader/Strategy/RedshiftStrategy.php
+++ b/Reader/Strategy/RedshiftStrategy.php
@@ -82,10 +82,6 @@ class RedshiftStrategy extends AbstractStrategy
         );
         $workspaceJobs[] = $job['id'];
 
-
-        $workspaceJobs = [];
-        $workspaceTables = [];
-
         if ($workspaceJobs) {
             $this->logger->info('Processing ' . count($workspaceJobs) . ' workspace exports.');
             $this->storageClient->handleAsyncTasks($workspaceJobs);

--- a/Reader/Strategy/RedshiftStrategy.php
+++ b/Reader/Strategy/RedshiftStrategy.php
@@ -27,5 +27,4 @@ class RedshiftStrategy extends SnowflakeStrategy
             'type' => 'copy',
         ];
     }
-
 }

--- a/Reader/Strategy/RedshiftStrategy.php
+++ b/Reader/Strategy/RedshiftStrategy.php
@@ -6,7 +6,7 @@ use Keboola\InputMapping\Reader\LoadTypeDecider;
 use Keboola\InputMapping\Reader\Options\InputTableOptions;
 use Keboola\InputMapping\Reader\WorkspaceProviderInterface;
 
-class RedshiftStrategy extends AbstractStrategy
+class RedshiftStrategy extends SnowflakeStrategy
 {
     protected $workspaceProviderId = WorkspaceProviderInterface::TYPE_REDSHIFT;
 
@@ -28,68 +28,4 @@ class RedshiftStrategy extends AbstractStrategy
         ];
     }
 
-    public function handleExports($exports)
-    {
-        $cloneInputs = [];
-        $copyInputs = [];
-
-        foreach ($exports as $export) {
-            if ($export['type'] === 'clone') {
-                /** @var InputTableOptions $table */
-                $table = $export['table'];
-                $cloneInputs[] = [
-                    'source' => $table->getSource(),
-                    'destination' => $table->getDestination()
-                ];
-                $workspaceTables[] = $table;
-            }
-            if ($export['type'] === 'copy') {
-                list ($table, $exportOptions) = $export['table'];
-                $copyInputs[] = array_merge(
-                    [
-                        'source' => $table->getSource(),
-                        'destination' => $table->getDestination(),
-                    ],
-                    $exportOptions
-                );
-                $workspaceTables[] = $table;
-            }
-        }
-
-        $this->logger->info(
-            sprintf('Cloning %s tables to %s workspace.', count($cloneInputs), $this->workspaceProviderId)
-        );
-        $job = $this->storageClient->apiPost(
-            'storage/workspaces/' . $this->workspaceProvider->getWorkspaceId($this->workspaceProviderId) . '/load-clone',
-            [
-                'input' => $cloneInputs,
-                'preserve' => 1,
-            ],
-            false
-        );
-        $workspaceJobs[] = $job['id'];
-
-        $this->logger->info(
-            sprintf('Copying %s tables to %s workspace.', count($copyInputs), $this->workspaceProviderId)
-        );
-        $job = $this->storageClient->apiPost(
-            'storage/workspaces/' . $this->workspaceProvider->getWorkspaceId($this->workspaceProviderId) . '/load',
-            [
-                'input' => $copyInputs,
-                'preserve' => 1,
-            ],
-            false
-        );
-        $workspaceJobs[] = $job['id'];
-
-        if ($workspaceJobs) {
-            $this->logger->info('Processing ' . count($workspaceJobs) . ' workspace exports.');
-            $this->storageClient->handleAsyncTasks($workspaceJobs);
-            foreach ($workspaceTables as $table) {
-                $manifestPath = $this->getDestinationFilePath($this->destination, $table) . ".manifest";
-                $tableInfo = $this->storageClient->getTable($table->getSource());
-                $this->manifestWriter->writeTableManifest($tableInfo, $manifestPath, $table->getColumns());
-            }
-        }
-    }
 }

--- a/Reader/Strategy/S3Strategy.php
+++ b/Reader/Strategy/S3Strategy.php
@@ -7,7 +7,7 @@ use Keboola\StorageApi\Options\GetFileOptions;
 
 class S3Strategy extends AbstractStrategy
 {
-    public function downloadTable(InputTableOptions $table): array
+    public function downloadTable(InputTableOptions $table)
     {
         $exportOptions = $table->getStorageApiExportOptions($this->tablesState);
         $exportOptions['gzip'] = true;
@@ -18,7 +18,10 @@ class S3Strategy extends AbstractStrategy
     public function handleExports($exports)
     {
         $this->logger->info("Processing " . count($exports) . " S3 table exports.");
-        $results = $this->storageClient->handleAsyncTasks(array_keys($exports));
+        $jobIds = array_map(function ($export) {
+            return $export[0];
+        }, $exports);
+        $results = $this->storageClient->handleAsyncTasks($jobIds);
         $keyedResults = [];
         foreach ($results as $result) {
             $keyedResults[$result["id"]] = $result;

--- a/Reader/Strategy/S3Strategy.php
+++ b/Reader/Strategy/S3Strategy.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Keboola\InputMapping\Reader\Strategy;
+
+use Keboola\InputMapping\Reader\Options\InputTableOptions;
+use Keboola\StorageApi\Options\GetFileOptions;
+
+class S3Strategy extends AbstractStrategy
+{
+    public function downloadTable(InputTableOptions $table): array
+    {
+        $exportOptions = $table->getStorageApiExportOptions($this->tablesState);
+        $exportOptions['gzip'] = true;
+        $jobId = $this->storageClient->queueTableExport($table->getSource(), $exportOptions);
+        return [$jobId, $table];
+    }
+
+    public function handleExports($exports)
+    {
+        $this->logger->info("Processing " . count($exports) . " S3 table exports.");
+        $results = $this->storageClient->handleAsyncTasks(array_keys($exports));
+        $keyedResults = [];
+        foreach ($results as $result) {
+            $keyedResults[$result["id"]] = $result;
+        }
+
+        /** @var InputTableOptions $table */
+        foreach ($exports as $export) {
+            list ($jobId, $table) = $export;
+            $manifestPath = $this->getDestinationFilePath($this->destination, $table) . ".manifest";
+            $tableInfo = $this->storageClient->getTable($table->getSource());
+            $fileInfo = $this->storageClient->getFile(
+                $keyedResults[$jobId]["results"]["file"]["id"],
+                (new GetFileOptions())->setFederationToken(true)
+            )
+            ;
+            $tableInfo["s3"] = $this->getS3Info($fileInfo);
+            $this->manifestWriter->writeTableManifest($tableInfo, $manifestPath, $table->getColumns());
+        }
+    }
+
+    protected function getS3Info($fileInfo)
+    {
+        return [
+            "isSliced" => $fileInfo["isSliced"],
+            "region" => $fileInfo["region"],
+            "bucket" => $fileInfo["s3Path"]["bucket"],
+            "key" => $fileInfo["isSliced"] ? $fileInfo["s3Path"]["key"] . "manifest" : $fileInfo["s3Path"]["key"],
+            "credentials" => [
+                "access_key_id" => $fileInfo["credentials"]["AccessKeyId"],
+                "secret_access_key" => $fileInfo["credentials"]["SecretAccessKey"],
+                "session_token" => $fileInfo["credentials"]["SessionToken"]
+            ]
+        ];
+    }
+}

--- a/Reader/Strategy/SnowflakeStrategy.php
+++ b/Reader/Strategy/SnowflakeStrategy.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Keboola\InputMapping\Reader\Strategy;
+
+use Keboola\InputMapping\Reader\LoadTypeDecider;
+use Keboola\InputMapping\Reader\Options\InputTableOptions;
+use Keboola\InputMapping\Reader\WorkspaceProviderInterface;
+
+class SnowflakeStrategy extends RedshiftStrategy
+{
+    public function downloadTable(InputTableOptions $table)
+    {
+        $tableInfo = $this->storageClient->getTable($table->getSource());
+        $loadOptions = $table->getStorageApiLoadOptions($this->tablesState);
+        if (LoadTypeDecider::canClone($tableInfo, 'snowflake', $loadOptions)) {
+            $this->logger->info(sprintf('Table "%s" will be cloned.', $table->getSource()));
+            $workspaceClones[WorkspaceProviderInterface::TYPE_SNOWFLAKE][] = $table;
+        } else {
+            $this->logger->info(sprintf('Table "%s" will be copied.', $table->getSource()));
+            $workspaceCopies[WorkspaceProviderInterface::TYPE_SNOWFLAKE][] = [$table, $loadOptions];
+        }
+    }
+}

--- a/Reader/Strategy/SnowflakeStrategy.php
+++ b/Reader/Strategy/SnowflakeStrategy.php
@@ -6,7 +6,7 @@ use Keboola\InputMapping\Reader\LoadTypeDecider;
 use Keboola\InputMapping\Reader\Options\InputTableOptions;
 use Keboola\InputMapping\Reader\WorkspaceProviderInterface;
 
-class SnowflakeStrategy extends RedshiftStrategy
+class SnowflakeStrategy extends AbstractStrategy
 {
     protected $workspaceProviderId = WorkspaceProviderInterface::TYPE_SNOWFLAKE;
 
@@ -26,5 +26,71 @@ class SnowflakeStrategy extends RedshiftStrategy
             'table' => [$table, $loadOptions],
             'type' => 'copy',
         ];
+    }
+
+
+    public function handleExports($exports)
+    {
+        $cloneInputs = [];
+        $copyInputs = [];
+
+        foreach ($exports as $export) {
+            if ($export['type'] === 'clone') {
+                /** @var InputTableOptions $table */
+                $table = $export['table'];
+                $cloneInputs[] = [
+                    'source' => $table->getSource(),
+                    'destination' => $table->getDestination()
+                ];
+                $workspaceTables[] = $table;
+            }
+            if ($export['type'] === 'copy') {
+                list ($table, $exportOptions) = $export['table'];
+                $copyInputs[] = array_merge(
+                    [
+                        'source' => $table->getSource(),
+                        'destination' => $table->getDestination(),
+                    ],
+                    $exportOptions
+                );
+                $workspaceTables[] = $table;
+            }
+        }
+
+        $this->logger->info(
+            sprintf('Cloning %s tables to %s workspace.', count($cloneInputs), $this->workspaceProviderId)
+        );
+        $job = $this->storageClient->apiPost(
+            'storage/workspaces/' . $this->workspaceProvider->getWorkspaceId($this->workspaceProviderId) . '/load-clone',
+            [
+                'input' => $cloneInputs,
+                'preserve' => 1,
+            ],
+            false
+        );
+        $workspaceJobs[] = $job['id'];
+
+        $this->logger->info(
+            sprintf('Copying %s tables to %s workspace.', count($copyInputs), $this->workspaceProviderId)
+        );
+        $job = $this->storageClient->apiPost(
+            'storage/workspaces/' . $this->workspaceProvider->getWorkspaceId($this->workspaceProviderId) . '/load',
+            [
+                'input' => $copyInputs,
+                'preserve' => 1,
+            ],
+            false
+        );
+        $workspaceJobs[] = $job['id'];
+
+        if ($workspaceJobs) {
+            $this->logger->info('Processing ' . count($workspaceJobs) . ' workspace exports.');
+            $this->storageClient->handleAsyncTasks($workspaceJobs);
+            foreach ($workspaceTables as $table) {
+                $manifestPath = $this->getDestinationFilePath($this->destination, $table) . ".manifest";
+                $tableInfo = $this->storageClient->getTable($table->getSource());
+                $this->manifestWriter->writeTableManifest($tableInfo, $manifestPath, $table->getColumns());
+            }
+        }
     }
 }

--- a/Reader/Strategy/SnowflakeStrategy.php
+++ b/Reader/Strategy/SnowflakeStrategy.php
@@ -8,16 +8,23 @@ use Keboola\InputMapping\Reader\WorkspaceProviderInterface;
 
 class SnowflakeStrategy extends RedshiftStrategy
 {
+    protected $workspaceProviderId = WorkspaceProviderInterface::TYPE_SNOWFLAKE;
+
     public function downloadTable(InputTableOptions $table)
     {
         $tableInfo = $this->storageClient->getTable($table->getSource());
         $loadOptions = $table->getStorageApiLoadOptions($this->tablesState);
         if (LoadTypeDecider::canClone($tableInfo, 'snowflake', $loadOptions)) {
             $this->logger->info(sprintf('Table "%s" will be cloned.', $table->getSource()));
-            $workspaceClones[WorkspaceProviderInterface::TYPE_SNOWFLAKE][] = $table;
-        } else {
-            $this->logger->info(sprintf('Table "%s" will be copied.', $table->getSource()));
-            $workspaceCopies[WorkspaceProviderInterface::TYPE_SNOWFLAKE][] = [$table, $loadOptions];
+            return [
+                'table' => $table,
+                'type' => 'clone'
+            ];
         }
+        $this->logger->info(sprintf('Table "%s" will be copied.', $table->getSource()));
+        return [
+            'table' => [$table, $loadOptions],
+            'type' => 'copy',
+        ];
     }
 }

--- a/Reader/Strategy/SnowflakeStrategy.php
+++ b/Reader/Strategy/SnowflakeStrategy.php
@@ -57,31 +57,36 @@ class SnowflakeStrategy extends AbstractStrategy
             }
         }
 
-        $this->logger->info(
-            sprintf('Cloning %s tables to %s workspace.', count($cloneInputs), $this->workspaceProviderId)
-        );
-        $job = $this->storageClient->apiPost(
-            'storage/workspaces/' . $this->workspaceProvider->getWorkspaceId($this->workspaceProviderId) . '/load-clone',
-            [
-                'input' => $cloneInputs,
-                'preserve' => 1,
-            ],
-            false
-        );
-        $workspaceJobs[] = $job['id'];
+        $workspaceJobs = [];
+        if ($cloneInputs) {
+            $this->logger->info(
+                sprintf('Cloning %s tables to %s workspace.', count($cloneInputs), $this->workspaceProviderId)
+            );
+            $job = $this->storageClient->apiPost(
+                'storage/workspaces/' . $this->workspaceProvider->getWorkspaceId($this->workspaceProviderId) . '/load-clone',
+                [
+                    'input' => $cloneInputs,
+                    'preserve' => 1,
+                ],
+                false
+            );
+            $workspaceJobs[] = $job['id'];
+        }
 
-        $this->logger->info(
-            sprintf('Copying %s tables to %s workspace.', count($copyInputs), $this->workspaceProviderId)
-        );
-        $job = $this->storageClient->apiPost(
-            'storage/workspaces/' . $this->workspaceProvider->getWorkspaceId($this->workspaceProviderId) . '/load',
-            [
-                'input' => $copyInputs,
-                'preserve' => 1,
-            ],
-            false
-        );
-        $workspaceJobs[] = $job['id'];
+        if ($copyInputs) {
+            $this->logger->info(
+                sprintf('Copying %s tables to %s workspace.', count($copyInputs), $this->workspaceProviderId)
+            );
+            $job = $this->storageClient->apiPost(
+                'storage/workspaces/' . $this->workspaceProvider->getWorkspaceId($this->workspaceProviderId) . '/load',
+                [
+                    'input' => $copyInputs,
+                    'preserve' => 1,
+                ],
+                false
+            );
+            $workspaceJobs[] = $job['id'];
+        }
 
         if ($workspaceJobs) {
             $this->logger->info('Processing ' . count($workspaceJobs) . ' workspace exports.');

--- a/Reader/Strategy/StrategyFactory.php
+++ b/Reader/Strategy/StrategyFactory.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\InputMapping\Reader\Strategy;
+
+use Keboola\InputMapping\Exception\InvalidInputException;
+use Keboola\InputMapping\Reader\State\InputTableStateList;
+use Keboola\InputMapping\Reader\WorkspaceProviderInterface;
+use Keboola\StorageApi\Client;
+use Psr\Log\LoggerInterface;
+
+class StrategyFactory
+{
+    const STAGING_S3 = 's3';
+    const STAGING_LOCAL = 'local';
+    const STAGING_SNOWFLAKE = 'workspace-snowflake';
+    const STAGING_REDSHIFT = 'workspace-redshift';
+
+    /** @var Client */
+    private $storageClient;
+
+    /** @var WorkspaceProviderInterface */
+    private $workspaceProvider;
+
+    /** LoggerInterface */
+    private $logger;
+
+    /** @var InputTableStateList */
+    protected $tablesState;
+
+    /** string */
+    protected $destination;
+
+    private $strategyMap = [
+        self::STAGING_S3 => S3Strategy::class,
+        self::STAGING_LOCAL => LocalStrategy::class,
+        self::STAGING_REDSHIFT => RedshiftStrategy::class,
+        self::STAGING_SNOWFLAKE => SnowflakeStrategy::class
+    ];
+
+    /** @var string */
+    private $format;
+
+    public function __construct(
+        Client $storageClient,
+        LoggerInterface $logger,
+        WorkspaceProviderInterface $workspaceProvider,
+        InputTableStateList $tablesState,
+        $destination,
+        $format = 'json'
+    ) {
+        $this->storageClient = $storageClient;
+        $this->logger = $logger;
+        $this->workspaceProvider = $workspaceProvider;
+        $this->tablesState = $tablesState;
+        $this->destination = $destination;
+        $this->format = $format;
+    }
+
+    public function getStrategy($storageType): StrategyInterface
+    {
+        $className = $this->getClassName($storageType);
+
+        if (!class_exists($className)) {
+            throw new InvalidInputException(
+                'Parameter "storage" must be one of: ' .
+                implode(
+                    ', ',
+                    [self::STAGING_LOCAL, self::STAGING_S3, self::STAGING_SNOWFLAKE, self::STAGING_REDSHIFT]
+                )
+            );
+        }
+
+        return new $className(
+            $this->storageClient,
+            $this->logger,
+            $this->workspaceProvider,
+            $this->tablesState,
+            $this->destination,
+            $this->format
+        );
+    }
+
+    private function getClassName($storageType)
+    {
+        return __NAMESPACE__ . '\\' . $this->strategyMap[$storageType];
+    }
+}

--- a/Reader/Strategy/StrategyFactory.php
+++ b/Reader/Strategy/StrategyFactory.php
@@ -62,9 +62,7 @@ class StrategyFactory
      */
     public function getStrategy($storageType)
     {
-        $className = $this->strategyMap[$storageType];
-
-        if (!class_exists($className)) {
+        if (!isset($this->strategyMap[$storageType])) {
             throw new InvalidInputException(
                 'Parameter "storage" must be one of: ' .
                 implode(
@@ -73,6 +71,8 @@ class StrategyFactory
                 )
             );
         }
+
+        $className = $this->strategyMap[$storageType];
 
         return new $className(
             $this->storageClient,

--- a/Reader/Strategy/StrategyFactory.php
+++ b/Reader/Strategy/StrategyFactory.php
@@ -67,7 +67,7 @@ class StrategyFactory
                 'Parameter "storage" must be one of: ' .
                 implode(
                     ', ',
-                    [self::STAGING_LOCAL, self::STAGING_S3, self::STAGING_SNOWFLAKE, self::STAGING_REDSHIFT]
+                    array_keys($this->strategyMap)
                 )
             );
         }

--- a/Reader/Strategy/StrategyFactory.php
+++ b/Reader/Strategy/StrategyFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Keboola\InputMapping\Reader\Strategy;
 
 use Keboola\InputMapping\Exception\InvalidInputException;
@@ -58,9 +56,13 @@ class StrategyFactory
         $this->format = $format;
     }
 
-    public function getStrategy($storageType): StrategyInterface
+    /**
+     * @param string $storageType
+     * @return StrategyInterface
+     */
+    public function getStrategy($storageType)
     {
-        $className = $this->getClassName($storageType);
+        $className = $this->strategyMap[$storageType];
 
         if (!class_exists($className)) {
             throw new InvalidInputException(
@@ -80,10 +82,5 @@ class StrategyFactory
             $this->destination,
             $this->format
         );
-    }
-
-    private function getClassName($storageType)
-    {
-        return __NAMESPACE__ . '\\' . $this->strategyMap[$storageType];
     }
 }

--- a/Reader/Strategy/StrategyInterface.php
+++ b/Reader/Strategy/StrategyInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Keboola\InputMapping\Reader\Strategy;
+
+use Keboola\InputMapping\Reader\Options\InputTableOptions;
+
+interface StrategyInterface
+{
+    public function downloadTable(InputTableOptions $table);
+    public function handleExports($exports);
+}

--- a/Tests/Reader/DownloadFilesRedshiftTest.php
+++ b/Tests/Reader/DownloadFilesRedshiftTest.php
@@ -4,17 +4,10 @@ namespace Keboola\InputMapping\Tests\Reader;
 
 use Keboola\Csv\CsvFile;
 use Keboola\InputMapping\Configuration\File\Manifest\Adapter;
-use Keboola\InputMapping\Exception\InputOperationException;
-use Keboola\InputMapping\Exception\InvalidInputException;
 use Keboola\InputMapping\Reader\NullWorkspaceProvider;
 use Keboola\InputMapping\Reader\Reader;
 use Keboola\StorageApi\Client;
-use Keboola\StorageApi\Options\FileUploadOptions;
-use Keboola\StorageApi\Options\GetFileOptions;
-use Keboola\StorageApi\Options\ListFilesOptions;
-use Keboola\Temp\Temp;
 use Psr\Log\NullLogger;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
 class DownloadFilesRedshiftTest extends DownloadFilesTestAbstract

--- a/Tests/Reader/DownloadTablesDefaultTest.php
+++ b/Tests/Reader/DownloadTablesDefaultTest.php
@@ -9,6 +9,7 @@ use Keboola\InputMapping\Reader\NullWorkspaceProvider;
 use Keboola\InputMapping\Reader\Options\InputTableOptionsList;
 use Keboola\InputMapping\Reader\Reader;
 use Keboola\InputMapping\Reader\State\InputTableStateList;
+use Keboola\InputMapping\Reader\Strategy\LocalStrategy;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Metadata;
@@ -340,8 +341,8 @@ class DownloadTablesDefaultTest extends DownloadTablesTestAbstract
     public function testReadTableLimitTest()
     {
         $tokenInfo = $this->client->verifyToken();
-        $tokenInfo['owner']['limits'][Reader::EXPORT_SIZE_LIMIT_NAME] = [
-            'name' => Reader::EXPORT_SIZE_LIMIT_NAME,
+        $tokenInfo['owner']['limits'][LocalStrategy::EXPORT_SIZE_LIMIT_NAME] = [
+            'name' => LocalStrategy::EXPORT_SIZE_LIMIT_NAME,
             'value' => 10,
         ];
         $client = self::getMockBuilder(Client::class)

--- a/Tests/Reader/DownloadTablesWorkspaceRedshiftTest.php
+++ b/Tests/Reader/DownloadTablesWorkspaceRedshiftTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Keboola\InputMapping\Tests\Reader;
+
+use Keboola\InputMapping\Configuration\Table\Manifest\Adapter;
+use Keboola\InputMapping\Reader\Options\InputTableOptionsList;
+use Keboola\InputMapping\Reader\Reader;
+use Keboola\InputMapping\Reader\State\InputTableStateList;
+use Keboola\StorageApi\Client;
+use Psr\Log\Test\TestLogger;
+
+class DownloadTablesWorkspaceRedshiftTest extends DownloadTablesWorkspaceTestAbstract
+{
+    public function testTablesRedshiftBackend()
+    {
+        $logger = new TestLogger();
+        $reader = new Reader($this->client, $logger, $this->getWorkspaceProvider());
+        $configuration = new InputTableOptionsList([
+            [
+                'source' => 'in.c-input-mapping-test.test1',
+                'destination' => 'test1',
+                'changed_since' => '-2 days',
+            ],
+            [
+                'source' => 'in.c-input-mapping-test.test2',
+                'destination' => 'test2',
+            ]
+        ]);
+
+        $reader->downloadTables(
+            $configuration,
+            new InputTableStateList([]),
+            $this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'download',
+            'workspace-redshift'
+        );
+
+        $adapter = new Adapter();
+
+        $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test1.manifest');
+        /* because of https://keboola.atlassian.net/browse/KBC-228 we have to create redshift bucket to
+            unload data from redshift workspace */
+        $this->client->dropBucket('out.c-input-mapping-test');
+        $this->client->createBucket('input-mapping-test', Client::STAGE_OUT, 'Docker Testsuite', 'redshift');
+
+        self::assertEquals('in.c-input-mapping-test.test1', $manifest['id']);
+        // test that the table exists in the workspace
+        $tableId = $this->client->createTableAsyncDirect(
+            'out.c-input-mapping-test',
+            ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test1', 'name' => 'test1']
+        );
+        self::assertEquals('out.c-input-mapping-test.test1', $tableId);
+
+        $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test2.manifest');
+        self::assertEquals('in.c-input-mapping-test.test2', $manifest['id']);
+        $tableId = $this->client->createTableAsyncDirect(
+            'out.c-input-mapping-test',
+            ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test2', 'name' => 'test2']
+        );
+        self::assertEquals('out.c-input-mapping-test.test2', $tableId);
+
+        self::assertTrue($logger->hasInfoThatContains('Table "in.c-input-mapping-test.test1" will be copied.'));
+        self::assertTrue($logger->hasInfoThatContains('Table "in.c-input-mapping-test.test2" will be copied.'));
+        self::assertTrue($logger->hasInfoThatContains('Processing 1 workspace exports.'));
+    }
+}

--- a/Tests/Reader/DownloadTablesWorkspaceSnowflakeTest.php
+++ b/Tests/Reader/DownloadTablesWorkspaceSnowflakeTest.php
@@ -2,83 +2,16 @@
 
 namespace Keboola\InputMapping\Tests\Reader;
 
-use Keboola\Csv\CsvFile;
 use Keboola\InputMapping\Configuration\Table\Manifest\Adapter;
 use Keboola\InputMapping\Exception\InvalidInputException;
-use Keboola\InputMapping\Reader\NullWorkspaceProvider;
 use Keboola\InputMapping\Reader\Options\InputTableOptionsList;
 use Keboola\InputMapping\Reader\Reader;
 use Keboola\InputMapping\Reader\State\InputTableStateList;
-use Keboola\InputMapping\Reader\WorkspaceProviderInterface;
-use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
-use Keboola\StorageApi\Workspaces;
 use Psr\Log\Test\TestLogger;
 
-class DownloadTablesWorkspaceTest extends DownloadTablesTestAbstract
+class DownloadTablesWorkspaceSnowflakeTest extends DownloadTablesWorkspaceTestAbstract
 {
-    private $workspaceId;
-
-    public function setUp()
-    {
-        parent::setUp();
-        try {
-            $this->client->dropBucket('in.c-input-mapping-test', ['force' => true]);
-        } catch (ClientException $e) {
-            if ($e->getCode() !== 404) {
-                throw $e;
-            }
-        }
-        try {
-            $this->client->dropBucket('out.c-input-mapping-test', ['force' => true]);
-        } catch (ClientException $e) {
-            if ($e->getCode() !== 404) {
-                throw $e;
-            }
-        }
-        $this->client->createBucket('input-mapping-test', Client::STAGE_IN, 'Docker Testsuite');
-        $this->client->createBucket('input-mapping-test', Client::STAGE_OUT, 'Docker Testsuite');
-
-        // Create table
-        $csv = new CsvFile($this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'upload.csv');
-        $csv->writeRow(['Id', 'Name', 'foo', 'bar']);
-        $csv->writeRow(['id1', 'name1', 'foo1', 'bar1']);
-        $csv->writeRow(['id2', 'name2', 'foo2', 'bar2']);
-        $csv->writeRow(['id3', 'name3', 'foo3', 'bar3']);
-        $this->client->createTableAsync('in.c-input-mapping-test', 'test1', $csv);
-        $this->client->createTableAsync('in.c-input-mapping-test', 'test2', $csv);
-        $this->client->createTableAsync('in.c-input-mapping-test', 'test3', $csv);
-    }
-
-    public function tearDown()
-    {
-        if ($this->workspaceId) {
-            $workspaces = new Workspaces($this->client);
-            $workspaces->deleteWorkspace($this->workspaceId);
-            $this->workspaceId = null;
-        }
-        parent::tearDown();
-    }
-
-    private function getWorkspaceProvider()
-    {
-        $mock = self::getMockBuilder(NullWorkspaceProvider::class)
-            ->setMethods(['getWorkspaceId'])
-            ->getMock();
-        $mock->method('getWorkspaceId')->willReturnCallback(
-            function ($type) {
-                if (!$this->workspaceId) {
-                    $workspaces = new Workspaces($this->client);
-                    $workspace = $workspaces->createWorkspace(['backend' => $type]);
-                    $this->workspaceId = $workspace['id'];
-                }
-                return $this->workspaceId;
-            }
-        );
-        /** @var WorkspaceProviderInterface $mock */
-        return $mock;
-    }
-
     public function testTablesSnowflakeBackend()
     {
         $logger = new TestLogger();
@@ -163,58 +96,6 @@ class DownloadTablesWorkspaceTest extends DownloadTablesTestAbstract
         self::assertEquals(2, count($params['input']));
         self::assertEquals('test1', $params['input'][0]['destination']);
         self::assertEquals('test3', $params['input'][1]['destination']);
-    }
-
-    public function testTablesRedshiftBackend()
-    {
-        $logger = new TestLogger();
-        $reader = new Reader($this->client, $logger, $this->getWorkspaceProvider());
-        $configuration = new InputTableOptionsList([
-            [
-                'source' => 'in.c-input-mapping-test.test1',
-                'destination' => 'test1',
-                'changed_since' => '-2 days',
-            ],
-            [
-                'source' => 'in.c-input-mapping-test.test2',
-                'destination' => 'test2',
-            ]
-        ]);
-
-        $reader->downloadTables(
-            $configuration,
-            new InputTableStateList([]),
-            $this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'download',
-            'workspace-redshift'
-        );
-
-        $adapter = new Adapter();
-
-        $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test1.manifest');
-        /* because of https://keboola.atlassian.net/browse/KBC-228 we have to create redshift bucket to
-            unload data from redshift workspace */
-        $this->client->dropBucket('out.c-input-mapping-test');
-        $this->client->createBucket('input-mapping-test', Client::STAGE_OUT, 'Docker Testsuite', 'redshift');
-
-        self::assertEquals('in.c-input-mapping-test.test1', $manifest['id']);
-        // test that the table exists in the workspace
-        $tableId = $this->client->createTableAsyncDirect(
-            'out.c-input-mapping-test',
-            ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test1', 'name' => 'test1']
-        );
-        self::assertEquals('out.c-input-mapping-test.test1', $tableId);
-
-        $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test2.manifest');
-        self::assertEquals('in.c-input-mapping-test.test2', $manifest['id']);
-        $tableId = $this->client->createTableAsyncDirect(
-            'out.c-input-mapping-test',
-            ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test2', 'name' => 'test2']
-        );
-        self::assertEquals('out.c-input-mapping-test.test2', $tableId);
-
-        self::assertTrue($logger->hasInfoThatContains('Table "in.c-input-mapping-test.test1" will be copied.'));
-        self::assertTrue($logger->hasInfoThatContains('Table "in.c-input-mapping-test.test2" will be copied.'));
-        self::assertTrue($logger->hasInfoThatContains('Processing 1 workspace exports.'));
     }
 
     public function testTablesInvalidMapping()

--- a/Tests/Reader/DownloadTablesWorkspaceTestAbstract.php
+++ b/Tests/Reader/DownloadTablesWorkspaceTestAbstract.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Keboola\InputMapping\Tests\Reader;
+
+use Keboola\Csv\CsvFile;
+use Keboola\InputMapping\Reader\NullWorkspaceProvider;
+use Keboola\InputMapping\Reader\WorkspaceProviderInterface;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
+use Keboola\StorageApi\Workspaces;
+
+class DownloadTablesWorkspaceTestAbstract extends DownloadTablesTestAbstract
+{
+    protected $workspaceId;
+
+    public function setUp()
+    {
+        parent::setUp();
+        try {
+            $this->client->dropBucket('in.c-input-mapping-test', ['force' => true]);
+        } catch (ClientException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+        }
+        try {
+            $this->client->dropBucket('out.c-input-mapping-test', ['force' => true]);
+        } catch (ClientException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+        }
+        $this->client->createBucket('input-mapping-test', Client::STAGE_IN, 'Docker Testsuite');
+        $this->client->createBucket('input-mapping-test', Client::STAGE_OUT, 'Docker Testsuite');
+
+        // Create table
+        $csv = new CsvFile($this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'upload.csv');
+        $csv->writeRow(['Id', 'Name', 'foo', 'bar']);
+        $csv->writeRow(['id1', 'name1', 'foo1', 'bar1']);
+        $csv->writeRow(['id2', 'name2', 'foo2', 'bar2']);
+        $csv->writeRow(['id3', 'name3', 'foo3', 'bar3']);
+        $this->client->createTableAsync('in.c-input-mapping-test', 'test1', $csv);
+        $this->client->createTableAsync('in.c-input-mapping-test', 'test2', $csv);
+        $this->client->createTableAsync('in.c-input-mapping-test', 'test3', $csv);
+    }
+
+    public function tearDown()
+    {
+        if ($this->workspaceId) {
+            $workspaces = new Workspaces($this->client);
+            $workspaces->deleteWorkspace($this->workspaceId);
+            $this->workspaceId = null;
+        }
+        parent::tearDown();
+    }
+
+    protected function getWorkspaceProvider()
+    {
+        $mock = self::getMockBuilder(NullWorkspaceProvider::class)
+            ->setMethods(['getWorkspaceId'])
+            ->getMock();
+        $mock->method('getWorkspaceId')->willReturnCallback(
+            function ($type) {
+                if (!$this->workspaceId) {
+                    $workspaces = new Workspaces($this->client);
+                    $workspace = $workspaces->createWorkspace(['backend' => $type]);
+                    $this->workspaceId = $workspace['id'];
+                }
+                return $this->workspaceId;
+            }
+        );
+        /** @var WorkspaceProviderInterface $mock */
+        return $mock;
+    }
+}

--- a/Tests/Reader/LoadTypeDeciderTest.php
+++ b/Tests/Reader/LoadTypeDeciderTest.php
@@ -63,7 +63,7 @@ class LoadTypeDeciderTest extends \PHPUnit_Framework_TestCase
                 [],
                 true,
             ],
-            'cloneable redshift' => [
+            'redshift' => [
                 [
                     'id' => 'foo.bar',
                     'name' => 'bar',
@@ -71,7 +71,7 @@ class LoadTypeDeciderTest extends \PHPUnit_Framework_TestCase
                 ],
                 'redshift',
                 [],
-                true,
+                false,
             ],
         ];
     }

--- a/Tests/Reader/ReaderTest.php
+++ b/Tests/Reader/ReaderTest.php
@@ -109,7 +109,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
 
         self::expectException(InvalidInputException::class);
         self::expectExceptionMessage(
-            'Parameter "storage" must be one of: local, s3, workspace-snowflake, workspace-redshift'
+            'Parameter "storage" must be one of: s3, local, workspace-redshift, workspace-snowflake'
         );
         $reader->downloadTables(
             $configuration,

--- a/Tests/Reader/ReaderTest.php
+++ b/Tests/Reader/ReaderTest.php
@@ -2,7 +2,6 @@
 
 namespace Keboola\InputMapping\Tests\Reader;
 
-use Keboola\InputMapping\Configuration\Table\Manifest\Adapter;
 use Keboola\InputMapping\Exception\InvalidInputException;
 use Keboola\InputMapping\Reader\NullWorkspaceProvider;
 use Keboola\InputMapping\Reader\Options\InputTableOptionsList;
@@ -107,7 +106,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
                 'destination' => 'test2.csv'
             ]
         ]);
-        
+
         self::expectException(InvalidInputException::class);
         self::expectExceptionMessage(
             'Parameter "storage" must be one of: local, s3, workspace-snowflake, workspace-redshift'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,9 @@
             <file>Tests/Reader/DownloadTablesAdaptiveTest.php</file>
             <file>Tests/Reader/DownloadTablesDefaultTest.php</file>
             <file>Tests/Reader/DownloadTablesOutputStateTest.php</file>
+            <file>Tests/Reader/DownloadTablesWorkspaceTest.php</file>
+            <file>Tests/Reader/LoadTypeDeciderTest.php</file>
+            <file>Tests/Reader/NullWorkspaceProviderTest.php</file>
             <file>Tests/Reader/ReaderTest.php</file>
             <file>Tests/Reader/TableDefinitionResolverTest.php</file>
         </testsuite>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,18 +12,10 @@
 
     <testsuites>
         <testsuite name="Common">
-            <directory>Tests/Configuration</directory>
-            <directory>Tests/Keboola</directory>
-            <directory>Tests/Reader/Options</directory>
-            <file>Tests/Reader/DownloadFilesTest.php</file>
-            <file>Tests/Reader/DownloadTablesAdaptiveTest.php</file>
-            <file>Tests/Reader/DownloadTablesDefaultTest.php</file>
-            <file>Tests/Reader/DownloadTablesOutputStateTest.php</file>
-            <file>Tests/Reader/DownloadTablesWorkspaceTest.php</file>
-            <file>Tests/Reader/LoadTypeDeciderTest.php</file>
-            <file>Tests/Reader/NullWorkspaceProviderTest.php</file>
-            <file>Tests/Reader/ReaderTest.php</file>
-            <file>Tests/Reader/TableDefinitionResolverTest.php</file>
+            <directory>Tests</directory>
+            <exclude>Tests/Reader/DownloadFilesRedshiftTest.php</exclude>
+            <exclude>Tests/Reader/DownloadTablesRedshiftTest.php</exclude>
+            <exclude>Tests/Reader/DownloadTablesS3DefaultTest.php</exclude>
         </testsuite>
         <testsuite name="Redshift">
             <file>Tests/Reader/DownloadFilesRedshiftTest.php</file>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,10 +16,12 @@
             <exclude>Tests/Reader/DownloadFilesRedshiftTest.php</exclude>
             <exclude>Tests/Reader/DownloadTablesRedshiftTest.php</exclude>
             <exclude>Tests/Reader/DownloadTablesS3DefaultTest.php</exclude>
+            <exclude>Tests/Reader/DownloadTablesWorkspaceRedshiftTest.php</exclude>
         </testsuite>
         <testsuite name="Redshift">
             <file>Tests/Reader/DownloadFilesRedshiftTest.php</file>
             <file>Tests/Reader/DownloadTablesRedshiftTest.php</file>
+            <file>Tests/Reader/DownloadTablesWorkspaceRedshiftTest.php</file>
         </testsuite>
         <testsuite name="S3">
             <file>Tests/Reader/DownloadTablesS3DefaultTest.php</file>


### PR DESCRIPTION
Vyskusal som spravit takyto refactoring:
- rozdelil som metodu Reader::downloadTables do jednotlivych "Strategy" tried podla backendu
- kazda Strategy trieda pretazuje metody `downloadTable` a `handleExports`, ktore sa volaju z metody `downloadTables` v AbstractStrategy 
- testy ostali nezmenene ale je teraz mozne kazdu strategy testovat samostatne