### PR TITLE
Data types support

### DIFF
--- a/Configuration/Table.php
+++ b/Configuration/Table.php
@@ -35,7 +35,31 @@ class Table extends Configuration
                 ->scalarNode("changed_since")
                     ->treatNullLike("")
                 ->end()
-                ->arrayNode("columns")->prototype("scalar")->end()->end()
+                ->arrayNode("columns")
+                    ->beforeNormalization()
+                        ->always()
+                        ->then(function ($array) {
+                            foreach ($array as $index => $value) {
+                                if (is_scalar($value)) {
+                                    $array[$index] = ['source' => $value];
+                                }
+                            }
+                            return $array;
+                        })
+                    ->end()
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('source')->isRequired()->end()
+                            ->scalarNode('type')->end()
+                            ->scalarNode('destination')->end()
+                            ->scalarNode('type')->end()
+                            ->scalarNode('length')->end()
+                            ->scalarNode('nullable')->end()
+                            ->scalarNode('convertEmptyValuesToNull')->end()
+                            ->scalarNode('compression')->end()
+                        ->end()
+                    ->end()
+                ->end()
                 ->scalarNode("where_column")->end()
                 ->integerNode("limit")->end()
                 ->arrayNode("where_values")->prototype("scalar")->end()->end()

--- a/Reader/Strategy/LocalStrategy.php
+++ b/Reader/Strategy/LocalStrategy.php
@@ -31,8 +31,7 @@ class LocalStrategy extends AbstractStrategy
             ));
         }
 
-        $this->manifestWriter->writeTableManifest($tableInfo, $file . ".manifest", $table->getColumns());
-
+        $this->manifestWriter->writeTableManifest($tableInfo, $file . ".manifest", $table->getColumnNames());
         return [
             "tableId" => $table->getSource(),
             "destination" => $file,

--- a/Reader/Strategy/S3Strategy.php
+++ b/Reader/Strategy/S3Strategy.php
@@ -12,14 +12,14 @@ class S3Strategy extends AbstractStrategy
         $exportOptions = $table->getStorageApiExportOptions($this->tablesState);
         $exportOptions['gzip'] = true;
         $jobId = $this->storageClient->queueTableExport($table->getSource(), $exportOptions);
-        return [$jobId, $table];
+        return ['jobId' => $jobId, 'table' => $table];
     }
 
     public function handleExports($exports)
     {
         $this->logger->info("Processing " . count($exports) . " S3 table exports.");
         $jobIds = array_map(function ($export) {
-            return $export[0];
+            return $export['jobId'];
         }, $exports);
         $results = $this->storageClient->handleAsyncTasks($jobIds);
         $keyedResults = [];
@@ -29,16 +29,16 @@ class S3Strategy extends AbstractStrategy
 
         /** @var InputTableOptions $table */
         foreach ($exports as $export) {
-            list ($jobId, $table) = $export;
+            $table = $export['table'];
             $manifestPath = $this->getDestinationFilePath($this->destination, $table) . ".manifest";
             $tableInfo = $this->storageClient->getTable($table->getSource());
             $fileInfo = $this->storageClient->getFile(
-                $keyedResults[$jobId]["results"]["file"]["id"],
+                $keyedResults[$export['jobId']]["results"]["file"]["id"],
                 (new GetFileOptions())->setFederationToken(true)
             )
             ;
             $tableInfo["s3"] = $this->getS3Info($fileInfo);
-            $this->manifestWriter->writeTableManifest($tableInfo, $manifestPath, $table->getColumns());
+            $this->manifestWriter->writeTableManifest($tableInfo, $manifestPath, $table->getColumnNames());
         }
     }
 

--- a/Reader/Strategy/SnowflakeStrategy.php
+++ b/Reader/Strategy/SnowflakeStrategy.php
@@ -28,7 +28,6 @@ class SnowflakeStrategy extends AbstractStrategy
         ];
     }
 
-
     public function handleExports($exports)
     {
         $cloneInputs = [];
@@ -94,7 +93,7 @@ class SnowflakeStrategy extends AbstractStrategy
             foreach ($workspaceTables as $table) {
                 $manifestPath = $this->getDestinationFilePath($this->destination, $table) . ".manifest";
                 $tableInfo = $this->storageClient->getTable($table->getSource());
-                $this->manifestWriter->writeTableManifest($tableInfo, $manifestPath, $table->getColumns());
+                $this->manifestWriter->writeTableManifest($tableInfo, $manifestPath, $table->getColumnNames());
             }
         }
     }

--- a/Tests/Configuration/TableConfigurationTest.php
+++ b/Tests/Configuration/TableConfigurationTest.php
@@ -23,6 +23,22 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
                 ],
+                [
+                    "source" => "in.c-main.test",
+                    "destination" => "test",
+                    "changed_since" => "-1 days",
+                    "columns" => [
+                        [
+                            'source' => "Id",
+                        ],
+                        [
+                            'source' => "Name",
+                        ],
+                    ],
+                    "where_column" => "status",
+                    "where_values" => ["val1", "val2"],
+                    "where_operator" => "ne",
+                ],
             ],
             'DaysNullConfiguration' => [
                 [
@@ -30,6 +46,22 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "destination" => "test",
                     "days" => null,
                     "columns" => ["Id", "Name"],
+                    "where_column" => "status",
+                    "where_values" => ["val1", "val2"],
+                    "where_operator" => "ne",
+                ],
+                [
+                    "source" => "in.c-main.test",
+                    "destination" => "test",
+                    "days" => null,
+                    "columns" => [
+                        [
+                            'source' => "Id",
+                        ],
+                        [
+                            'source' => "Name",
+                        ],
+                    ],
                     "where_column" => "status",
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
@@ -45,6 +77,22 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
                 ],
+                [
+                    "source" => "in.c-main.test",
+                    "destination" => "test",
+                    "days" => 1,
+                    "columns" => [
+                        [
+                            'source' => "Id",
+                        ],
+                        [
+                            'source' => "Name",
+                        ],
+                    ],
+                    "where_column" => "status",
+                    "where_values" => ["val1", "val2"],
+                    "where_operator" => "ne",
+                ],
             ],
             'ChangedSinceNullConfiguration' => [
                 [
@@ -56,6 +104,22 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
                 ],
+                [
+                    "source" => "in.c-main.test",
+                    "destination" => "test",
+                    "changed_since" => null,
+                    "columns" => [
+                        [
+                            'source' => "Id",
+                        ],
+                        [
+                            'source' => "Name",
+                        ],
+                    ],
+                    "where_column" => "status",
+                    "where_values" => ["val1", "val2"],
+                    "where_operator" => "ne",
+                ],
             ],
             'ChangedSinceConfiguration' => [
                 [
@@ -63,6 +127,22 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "destination" => "test",
                     "changed_since" => "-1 days",
                     "columns" => ["Id", "Name"],
+                    "where_column" => "status",
+                    "where_values" => ["val1", "val2"],
+                    "where_operator" => "ne",
+                ],
+                [
+                    "source" => "in.c-main.test",
+                    "destination" => "test",
+                    "changed_since" => "-1 days",
+                    "columns" => [
+                        [
+                            'source' => "Id",
+                        ],
+                        [
+                            'source' => "Name",
+                        ],
+                    ],
                     "where_column" => "status",
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
@@ -81,13 +161,96 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
                 ],
+                [
+                    "source_search" => [
+                        "key" => "bdm.scaffold.tag",
+                        "value" => "test_table",
+                    ],
+                    "destination" => "test",
+                    "changed_since" => "-1 days",
+                    "columns" => [
+                        [
+                            'source' => "Id",
+                        ],
+                        [
+                            'source' => "Name",
+                        ],
+                    ],
+                    "where_column" => "status",
+                    "where_values" => ["val1", "val2"],
+                    "where_operator" => "ne",
+                ],
             ],
-        ];
-    }
-
-    public function provideValidConfigsChanged()
-    {
-        return [
+            'DataTypesConfiguration' => [
+                [
+                    "source" => "foo",
+                    "destination" => "bar",
+                    "columns" => [
+                        [
+                            "source" => "Id",
+                            "type" => "VARCHAR",
+                        ],
+                        [
+                            "source" => "Name",
+                            "type" => "VARCHAR"
+                        ],
+                    ],
+                    "where_column" => "status",
+                    "where_values" => ["val1", "val2"],
+                    "where_operator" => "ne",
+                ],
+                [
+                    "source" => "foo",
+                    "destination" => "bar",
+                    "columns" => [
+                        [
+                            "source" => "Id",
+                            "type" => "VARCHAR",
+                        ],
+                        [
+                            "source" => "Name",
+                            "type" => "VARCHAR"
+                        ],
+                    ],
+                    "where_column" => "status",
+                    "where_values" => ["val1", "val2"],
+                    "where_operator" => "ne",
+                ],
+            ],
+            'FullDataTypesConfiguration' => [
+                [
+                    "source" => "foo",
+                    "destination" => "bar",
+                    "columns" => [
+                        [
+                            "source" => "Id",
+                            "type" => "VARCHAR",
+                            "destination" => "MyId",
+                            "length" => "10,2",
+                            "nullable" => true,
+                            "convertEmptyValuesToNull" => true,
+                            "compression" => "DELTA32K",
+                        ],
+                    ],
+                ],
+                [
+                    "source" => "foo",
+                    "destination" => "bar",
+                    "columns" => [
+                        [
+                            "source" => "Id",
+                            "type" => "VARCHAR",
+                            "destination" => "MyId",
+                            "length" => "10,2",
+                            "nullable" => true,
+                            "convertEmptyValuesToNull" => true,
+                            "compression" => "DELTA32K",
+                        ],
+                    ],
+                    "where_values" => [],
+                    "where_operator" => "eq",
+                ],
+            ],
             'BasicConfiguration' => [
                 [
                     "source" => "in.c-main.test",
@@ -99,29 +262,18 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_operator" => "eq",
                 ],
             ],
-
         ];
-    }
-
-    /**
-     * @dataProvider provideValidConfigsChanged
-     */
-    public function testValidConfigDefinitionChanged(
-        array $config,
-        array $expected
-    ) {
-        $processedConfiguration = (new Table())->parse(["config" => $config]);
-        self::assertEquals($expected, $processedConfiguration);
     }
 
     /**
      * @dataProvider provideValidConfigs
      */
     public function testValidConfigDefinition(
-        array $config
+        array $config,
+        array $expected
     ) {
         $processedConfiguration = (new Table())->parse(["config" => $config]);
-        self::assertEquals($config, $processedConfiguration);
+        self::assertEquals($expected, $processedConfiguration);
     }
 
     /**

--- a/Tests/Reader/DownloadTablesWorkspaceRedshiftTest.php
+++ b/Tests/Reader/DownloadTablesWorkspaceRedshiftTest.php
@@ -20,11 +20,22 @@ class DownloadTablesWorkspaceRedshiftTest extends DownloadTablesWorkspaceTestAbs
                 'source' => 'in.c-input-mapping-test.test1',
                 'destination' => 'test1',
                 'changed_since' => '-2 days',
+                'columns' => ['Id'],
             ],
             [
                 'source' => 'in.c-input-mapping-test.test2',
                 'destination' => 'test2',
-            ]
+                'columns' => [
+                    [
+                        'source' => 'Id',
+                        'type' => 'VARCHAR',
+                    ],
+                    [
+                        'source' => 'Name',
+                        'type' => 'VARCHAR',
+                    ],
+                ],
+            ],
         ]);
 
         $reader->downloadTables(
@@ -49,6 +60,8 @@ class DownloadTablesWorkspaceRedshiftTest extends DownloadTablesWorkspaceTestAbs
             ['dataWorkspaceId' => $this->workspaceId, 'dataTableName' => 'test1', 'name' => 'test1']
         );
         self::assertEquals('out.c-input-mapping-test.test1', $tableId);
+        $table = $this->client->getTable($tableId);
+        self::assertEquals(['id'], $table['columns']);
 
         $manifest = $adapter->readFromFile($this->temp->getTmpFolder() . '/download/test2.manifest');
         self::assertEquals('in.c-input-mapping-test.test2', $manifest['id']);

--- a/Tests/Reader/DownloadTablesWorkspaceSnowflakeTest.php
+++ b/Tests/Reader/DownloadTablesWorkspaceSnowflakeTest.php
@@ -179,6 +179,8 @@ class DownloadTablesWorkspaceSnowflakeTest extends DownloadTablesWorkspaceTestAb
             [
                 'source' => 'in.c-input-mapping-test.test2',
                 'destination' => 'test2',
+                'where_column' => 'Id',
+                'where_values' => ['id2'],
                 'columns' => [
                     [
                         'source' => 'Id',

--- a/Tests/Strategy/LocalStrategyTest.php
+++ b/Tests/Strategy/LocalStrategyTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Keboola\InputMapping\Tests\Strategy;
+
+use Keboola\Csv\CsvFile;
+use Keboola\InputMapping\Reader\NullWorkspaceProvider;
+use Keboola\InputMapping\Reader\Options\InputTableOptions;
+use Keboola\InputMapping\Reader\State\InputTableStateList;
+use Keboola\InputMapping\Reader\Strategy\LocalStrategy;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
+use Keboola\Temp\Temp;
+use Psr\Log\NullLogger;
+
+class LocalStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Client */
+    private $client;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->client = new Client(['token' => STORAGE_API_TOKEN, "url" => STORAGE_API_URL]);
+        try {
+            $this->client->dropBucket('in.c-input-mapping-test-strategy', ['force' => true]);
+        } catch (ClientException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+        }
+        $this->client->createBucket('input-mapping-test-strategy', Client::STAGE_IN, 'Docker Testsuite');
+
+        // Create table
+        $temp = new Temp();
+        $temp->initRunFolder();
+        $csv = new CsvFile($temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'upload.csv');
+        $csv->writeRow(['Id', 'Name', 'foo', 'bar']);
+        $csv->writeRow(['id1', 'name1', 'foo1', 'bar1']);
+        $csv->writeRow(['id2', 'name2', 'foo2', 'bar2']);
+        $csv->writeRow(['id3', 'name3', 'foo3', 'bar3']);
+        $this->client->createTableAsync('in.c-input-mapping-test-strategy', 'test1', $csv);
+    }
+
+    public function testColumns()
+    {
+        $strategy = new LocalStrategy(
+            $this->client,
+            new NullLogger(),
+            new NullWorkspaceProvider(),
+            new InputTableStateList([]),
+            '.'
+        );
+        $tableOptions = new InputTableOptions(
+           [
+               'source' => 'in.c-input-mapping-test-strategy.test1',
+               'destination' => 'some-table.csv',
+               'columns' => ['Id', 'Name']
+           ]
+        );
+        $result = $strategy->downloadTable($tableOptions);
+        self::assertEquals(
+            [
+                'tableId' => 'in.c-input-mapping-test-strategy.test1',
+                'destination' => './some-table.csv',
+                'exportOptions' => [
+                    'columns' => ['Id', 'Name']
+                ]
+            ],
+            $result
+        );
+    }
+
+    public function testColumnsExtended()
+    {
+        $strategy = new LocalStrategy(
+            $this->client,
+            new NullLogger(),
+            new NullWorkspaceProvider(),
+            new InputTableStateList([]),
+            '.'
+        );
+        $tableOptions = new InputTableOptions(
+            [
+                'source' => 'in.c-input-mapping-test-strategy.test1',
+                'destination' => 'some-table.csv',
+                'columns' => [
+                    [
+                        'source' => 'Id',
+                        'destination' => 'myid',
+                        'type' => 'VARCHAR'
+                    ],
+                    [
+                        'source' => 'Name',
+                        'destination' => 'myname',
+                        'type' => 'NUMERIC'
+                    ],
+                ],
+            ],
+        );
+        $result = $strategy->downloadTable($tableOptions);
+        self::assertEquals(
+            [
+                'tableId' => 'in.c-input-mapping-test-strategy.test1',
+                'destination' => './some-table.csv',
+                'exportOptions' => [
+                    'columns' => ['Id', 'Name']
+                ]
+            ],
+            $result
+        );
+    }
+}

--- a/Tests/Strategy/LocalStrategyTest.php
+++ b/Tests/Strategy/LocalStrategyTest.php
@@ -10,9 +10,10 @@ use Keboola\InputMapping\Reader\Strategy\LocalStrategy;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\Temp\Temp;
+use PHPUnit_Framework_TestCase;
 use Psr\Log\NullLogger;
 
-class LocalStrategyTest extends \PHPUnit_Framework_TestCase
+class LocalStrategyTest extends PHPUnit_Framework_TestCase
 {
     /** @var Client */
     private $client;
@@ -51,11 +52,11 @@ class LocalStrategyTest extends \PHPUnit_Framework_TestCase
             '.'
         );
         $tableOptions = new InputTableOptions(
-           [
-               'source' => 'in.c-input-mapping-test-strategy.test1',
-               'destination' => 'some-table.csv',
-               'columns' => ['Id', 'Name']
-           ]
+            [
+                'source' => 'in.c-input-mapping-test-strategy.test1',
+                'destination' => 'some-table.csv',
+                'columns' => ['Id', 'Name']
+            ]
         );
         $result = $strategy->downloadTable($tableOptions);
         self::assertEquals(

--- a/Tests/Strategy/LocalStrategyTest.php
+++ b/Tests/Strategy/LocalStrategyTest.php
@@ -96,7 +96,7 @@ class LocalStrategyTest extends PHPUnit_Framework_TestCase
                         'type' => 'NUMERIC'
                     ],
                 ],
-            ],
+            ]
         );
         $result = $strategy->downloadTable($tableOptions);
         self::assertEquals(

--- a/Tests/Strategy/S3StrategyTest.php
+++ b/Tests/Strategy/S3StrategyTest.php
@@ -6,7 +6,6 @@ use Keboola\Csv\CsvFile;
 use Keboola\InputMapping\Reader\NullWorkspaceProvider;
 use Keboola\InputMapping\Reader\Options\InputTableOptions;
 use Keboola\InputMapping\Reader\State\InputTableStateList;
-use Keboola\InputMapping\Reader\Strategy\LocalStrategy;
 use Keboola\InputMapping\Reader\Strategy\S3Strategy;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
@@ -97,7 +96,7 @@ class S3StrategyTest extends \PHPUnit_Framework_TestCase
                         'type' => 'NUMERIC'
                     ],
                 ],
-            ],
+            ]
         );
         $result = $strategy->downloadTable($tableOptions);
         self::assertArrayHasKey('jobId', $result);

--- a/Tests/Strategy/S3StrategyTest.php
+++ b/Tests/Strategy/S3StrategyTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Keboola\InputMapping\Tests\Strategy;
+
+use Keboola\Csv\CsvFile;
+use Keboola\InputMapping\Reader\NullWorkspaceProvider;
+use Keboola\InputMapping\Reader\Options\InputTableOptions;
+use Keboola\InputMapping\Reader\State\InputTableStateList;
+use Keboola\InputMapping\Reader\Strategy\LocalStrategy;
+use Keboola\InputMapping\Reader\Strategy\S3Strategy;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
+use Keboola\Temp\Temp;
+use Psr\Log\NullLogger;
+
+class S3StrategyTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Client */
+    private $client;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->client = new Client(['token' => STORAGE_API_TOKEN, "url" => STORAGE_API_URL]);
+        try {
+            $this->client->dropBucket('in.c-input-mapping-test-strategy', ['force' => true]);
+        } catch (ClientException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+        }
+        $this->client->createBucket('input-mapping-test-strategy', Client::STAGE_IN, 'Docker Testsuite');
+
+        // Create table
+        $temp = new Temp();
+        $temp->initRunFolder();
+        $csv = new CsvFile($temp->getTmpFolder() . DIRECTORY_SEPARATOR . 'upload.csv');
+        $csv->writeRow(['Id', 'Name', 'foo', 'bar']);
+        $csv->writeRow(['id1', 'name1', 'foo1', 'bar1']);
+        $csv->writeRow(['id2', 'name2', 'foo2', 'bar2']);
+        $csv->writeRow(['id3', 'name3', 'foo3', 'bar3']);
+        $this->client->createTableAsync('in.c-input-mapping-test-strategy', 'test1', $csv);
+    }
+
+    public function testColumns()
+    {
+        $strategy = new S3Strategy(
+            $this->client,
+            new NullLogger(),
+            new NullWorkspaceProvider(),
+            new InputTableStateList([]),
+            '.'
+        );
+        $tableOptions = new InputTableOptions(
+            [
+                'source' => 'in.c-input-mapping-test-strategy.test1',
+                'destination' => 'some-table.csv',
+                'columns' => ['Id', 'Name']
+            ]
+        );
+        $result = $strategy->downloadTable($tableOptions);
+        self::assertArrayHasKey('jobId', $result);
+        self::assertArrayHasKey('table', $result);
+        $job = $this->client->getJob($result['jobId']);
+        self::assertEquals(
+            'tableExport',
+            $job['operationName']
+        );
+        self::assertEquals(
+            ['Id', 'Name'],
+            $job['operationParams']['export']['columns']
+        );
+    }
+
+    public function testColumnsExtended()
+    {
+        $strategy = new S3Strategy(
+            $this->client,
+            new NullLogger(),
+            new NullWorkspaceProvider(),
+            new InputTableStateList([]),
+            '.'
+        );
+        $tableOptions = new InputTableOptions(
+            [
+                'source' => 'in.c-input-mapping-test-strategy.test1',
+                'destination' => 'some-table.csv',
+                'columns' => [
+                    [
+                        'source' => 'Id',
+                        'destination' => 'myid',
+                        'type' => 'VARCHAR'
+                    ],
+                    [
+                        'source' => 'Name',
+                        'destination' => 'myname',
+                        'type' => 'NUMERIC'
+                    ],
+                ],
+            ],
+        );
+        $result = $strategy->downloadTable($tableOptions);
+        self::assertArrayHasKey('jobId', $result);
+        self::assertArrayHasKey('table', $result);
+        $job = $this->client->getJob($result['jobId']);
+        self::assertEquals(
+            'tableExport',
+            $job['operationName']
+        );
+        self::assertEquals(
+            ['Id', 'Name'],
+            $job['operationParams']['export']['columns']
+        );
+    }
+}


### PR DESCRIPTION
Je to based on miro-refactoring, ale mergnul bych nejdriv ten refactoring a pak az teprv tohle.

Problem je v tom, ze cally https://keboola.docs.apiary.io/#reference/workspaces/load-data/load-data a https://keboola.docs.apiary.io/#reference/tables/unload-data-asynchronously/asynchronous-export nemaji stejne zadavany columns. 
Druhej problem je v tom, ze v soucasne verzi se columns zadava jako pole scalaru https://github.com/keboola/input-mapping/pull/52/files#diff-a4296f364a5e819e99204f3ecb4884ceL38 a ten format je nezavislej na typu loadu (csv, s3, workspace).

Jako prvni jsem teda udelal to, ze jsem columns rozsiril na pole objektu a pridal tam normalizaci z puvodniho formatu https://github.com/keboola/input-mapping/pull/52/files#diff-a4296f364a5e819e99204f3ecb4884ceR39 - tzn. oba zapisy jsou zvenku mozny a je to zpetne kompatibilni.

Tim se ale pak dostanu do srabu v tom, ze tady https://keboola.docs.apiary.io/#reference/workspaces/load-data/load-data je povinny zadat type. Resp. ono to ma nezdokumentovanou ficuru, ze load data to workspace prijima pole objektu (pak to loaduje s datovymi typy) nebo pole stringu (pak to loaduje bez datovych typu - tak to funguje doted). Timpadem jsem sem https://github.com/keboola/input-mapping/pull/52/files#diff-b7b5320ee9976c0ce0148f8c3714803bR32 pridal kontrolu, ze datove typy jsou bud vsude nebo nikde. 

Obycejnej export jsem potom upravil, aby loadoval jen nazvy sloupcu https://github.com/keboola/input-mapping/pull/52/files#diff-b7b5320ee9976c0ce0148f8c3714803bR87 a workspacovej tak, aby pouzival bud format s typy nebo bez https://github.com/keboola/input-mapping/pull/52/files#diff-b7b5320ee9976c0ce0148f8c3714803bR128 a stejne tak aby byly nazvy sloupcu jen v manifestech https://github.com/keboola/input-mapping/pull/52/files#diff-08c6af2e29db3141007efba561c088a1R96

a tohle jsem se nejak pokusil pokryt testama :)
