### PR TITLE
refactor: redo column types with a new column_types field

### DIFF
--- a/Configuration/Table.php
+++ b/Configuration/Table.php
@@ -35,18 +35,10 @@ class Table extends Configuration
                 ->scalarNode("changed_since")
                     ->treatNullLike("")
                 ->end()
-                ->arrayNode("columns")
-                    ->beforeNormalization()
-                        ->always()
-                        ->then(function ($array) {
-                            foreach ($array as $index => $value) {
-                                if (is_scalar($value)) {
-                                    $array[$index] = ['source' => $value];
-                                }
-                            }
-                            return $array;
-                        })
-                    ->end()
+                ->arrayNode('columns')
+                    ->prototype('scalar')->end()
+                ->end()
+                ->arrayNode('column_types')
                     ->prototype('array')
                         ->children()
                             ->scalarNode('source')->isRequired()->end()
@@ -55,7 +47,7 @@ class Table extends Configuration
                             ->scalarNode('type')->end()
                             ->scalarNode('length')->end()
                             ->scalarNode('nullable')->end()
-                            ->scalarNode('convertEmptyValuesToNull')->end()
+                            ->scalarNode('convert_empty_values_to_null')->end()
                             ->scalarNode('compression')->end()
                         ->end()
                     ->end()

--- a/Reader/Options/InputTableOptions.php
+++ b/Reader/Options/InputTableOptions.php
@@ -39,14 +39,14 @@ class InputTableOptions
             $diff = array_diff($this->definition['columns'], $colNamesFromTypes);
             if ($diff) {
                 throw new InvalidInputException(sprintf(
-                    'Both columns and column_types are specified, columns field contains surplus columns: %s.',
+                    'Both "columns" and "column_types" are specified, "columns" field contains surplus columns: "%s".',
                     implode($diff, ', ')
                 ));
             }
             $diff = array_diff($colNamesFromTypes, $this->definition['columns']);
             if ($diff) {
                 throw new InvalidInputException(sprintf(
-                    'Both columns and column_types are specified, column_types field contains surplus columns: %s.',
+                    'Both "columns" and "column_types" are specified, "column_types" field contains surplus columns: "%s".',
                     implode($diff, ', ')
                 ));
             }

--- a/Reader/Strategy/ABSStrategy.php
+++ b/Reader/Strategy/ABSStrategy.php
@@ -40,7 +40,7 @@ class ABSStrategy extends AbstractStrategy
             )
             ;
             $tableInfo["abs"] = $this->getABSInfo($fileInfo);
-            $this->manifestWriter->writeTableManifest($tableInfo, $manifestPath, $table->getColumns());
+            $this->manifestWriter->writeTableManifest($tableInfo, $manifestPath, $table->getColumnNames());
         }
     }
 

--- a/Reader/Strategy/ABSStrategy.php
+++ b/Reader/Strategy/ABSStrategy.php
@@ -2,6 +2,7 @@
 
 namespace Keboola\InputMapping\Reader\Strategy;
 
+use Keboola\InputMapping\Exception\InvalidInputException;
 use Keboola\InputMapping\Reader\Options\InputTableOptions;
 use Keboola\StorageApi\Options\GetFileOptions;
 
@@ -45,6 +46,9 @@ class ABSStrategy extends AbstractStrategy
 
     protected function getABSInfo($fileInfo)
     {
+        if (empty($fileInfo['absPath'])) {
+            throw new InvalidInputException('This project does not have ABS backend.');
+        }
         return [
             "is_sliced" => $fileInfo["isSliced"],
             "region" => $fileInfo["region"],

--- a/Reader/Strategy/S3Strategy.php
+++ b/Reader/Strategy/S3Strategy.php
@@ -2,6 +2,7 @@
 
 namespace Keboola\InputMapping\Reader\Strategy;
 
+use Keboola\InputMapping\Exception\InvalidInputException;
 use Keboola\InputMapping\Reader\Options\InputTableOptions;
 use Keboola\StorageApi\Options\GetFileOptions;
 
@@ -44,6 +45,9 @@ class S3Strategy extends AbstractStrategy
 
     protected function getS3Info($fileInfo)
     {
+        if (empty($fileInfo["credentials"]["AccessKeyId"])) {
+            throw new InvalidInputException('This project does not have S3 backend.');
+        }
         return [
             "isSliced" => $fileInfo["isSliced"],
             "region" => $fileInfo["region"],

--- a/Tests/Configuration/TableConfigurationTest.php
+++ b/Tests/Configuration/TableConfigurationTest.php
@@ -27,17 +27,11 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "source" => "in.c-main.test",
                     "destination" => "test",
                     "changed_since" => "-1 days",
-                    "columns" => [
-                        [
-                            'source' => "Id",
-                        ],
-                        [
-                            'source' => "Name",
-                        ],
-                    ],
+                    "columns" => ["Id", "Name"],
                     "where_column" => "status",
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
+                    "column_types" => [],
                 ],
             ],
             'DaysNullConfiguration' => [
@@ -54,17 +48,11 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "source" => "in.c-main.test",
                     "destination" => "test",
                     "days" => null,
-                    "columns" => [
-                        [
-                            'source' => "Id",
-                        ],
-                        [
-                            'source' => "Name",
-                        ],
-                    ],
+                    "columns" => ["Id", "Name"],
                     "where_column" => "status",
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
+                    "column_types" => [],
                 ],
             ],
             'DaysConfiguration' => [
@@ -81,17 +69,11 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "source" => "in.c-main.test",
                     "destination" => "test",
                     "days" => 1,
-                    "columns" => [
-                        [
-                            'source' => "Id",
-                        ],
-                        [
-                            'source' => "Name",
-                        ],
-                    ],
+                    "columns" => ["Id", "Name"],
                     "where_column" => "status",
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
+                    "column_types" => [],
                 ],
             ],
             'ChangedSinceNullConfiguration' => [
@@ -108,17 +90,11 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "source" => "in.c-main.test",
                     "destination" => "test",
                     "changed_since" => null,
-                    "columns" => [
-                        [
-                            'source' => "Id",
-                        ],
-                        [
-                            'source' => "Name",
-                        ],
-                    ],
+                    "columns" => ["Id", "Name"],
                     "where_column" => "status",
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
+                    "column_types" => [],
                 ],
             ],
             'ChangedSinceConfiguration' => [
@@ -135,17 +111,11 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "source" => "in.c-main.test",
                     "destination" => "test",
                     "changed_since" => "-1 days",
-                    "columns" => [
-                        [
-                            'source' => "Id",
-                        ],
-                        [
-                            'source' => "Name",
-                        ],
-                    ],
+                    "columns" => ["Id", "Name"],
                     "where_column" => "status",
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
+                    "column_types" => [],
                 ],
             ],
             'SearchSourceConfiguration' => [
@@ -168,24 +138,18 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     ],
                     "destination" => "test",
                     "changed_since" => "-1 days",
-                    "columns" => [
-                        [
-                            'source' => "Id",
-                        ],
-                        [
-                            'source' => "Name",
-                        ],
-                    ],
+                    "columns" => ["Id", "Name"],
                     "where_column" => "status",
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
+                    "column_types" => [],
                 ],
             ],
             'DataTypesConfiguration' => [
                 [
                     "source" => "foo",
                     "destination" => "bar",
-                    "columns" => [
+                    "column_types" => [
                         [
                             "source" => "Id",
                             "type" => "VARCHAR",
@@ -202,7 +166,8 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                 [
                     "source" => "foo",
                     "destination" => "bar",
-                    "columns" => [
+                    "columns" => [],
+                    "column_types" => [
                         [
                             "source" => "Id",
                             "type" => "VARCHAR",
@@ -221,14 +186,15 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                 [
                     "source" => "foo",
                     "destination" => "bar",
-                    "columns" => [
+                    "columns" => ["Id"],
+                    "column_types" => [
                         [
                             "source" => "Id",
                             "type" => "VARCHAR",
                             "destination" => "MyId",
                             "length" => "10,2",
                             "nullable" => true,
-                            "convertEmptyValuesToNull" => true,
+                            "convert_empty_values_to_null" => true,
                             "compression" => "DELTA32K",
                         ],
                     ],
@@ -236,19 +202,20 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                 [
                     "source" => "foo",
                     "destination" => "bar",
-                    "columns" => [
+                    "columns" => ["Id"],
+                    "where_values" => [],
+                    "where_operator" => "eq",
+                    "column_types" => [
                         [
                             "source" => "Id",
                             "type" => "VARCHAR",
                             "destination" => "MyId",
                             "length" => "10,2",
                             "nullable" => true,
-                            "convertEmptyValuesToNull" => true,
+                            "convert_empty_values_to_null" => true,
                             "compression" => "DELTA32K",
                         ],
                     ],
-                    "where_values" => [],
-                    "where_operator" => "eq",
                 ],
             ],
             'BasicConfiguration' => [
@@ -260,6 +227,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "columns" => [],
                     "where_values" => [],
                     "where_operator" => "eq",
+                    "column_types" => [],
                 ],
             ],
         ];
@@ -350,6 +318,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
         $expectedArray["where_operator"] = "eq";
         $expectedArray["columns"] = [];
         $expectedArray["where_values"] = [];
+        $expectedArray["column_types"] = [];
         $processedConfiguration = (new Table())->parse(["config" => $config]);
         self::assertEquals($expectedArray, $processedConfiguration);
     }

--- a/Tests/Reader/DownloadTablesABSDefaultTest.php
+++ b/Tests/Reader/DownloadTablesABSDefaultTest.php
@@ -4,6 +4,7 @@ namespace Keboola\InputMapping\Tests\Reader;
 
 use Keboola\Csv\CsvFile;
 use Keboola\InputMapping\Configuration\Table\Manifest\Adapter;
+use Keboola\InputMapping\Exception\InvalidInputException;
 use Keboola\InputMapping\Reader\NullWorkspaceProvider;
 use Keboola\InputMapping\Reader\Options\InputTableOptionsList;
 use Keboola\InputMapping\Reader\Reader;
@@ -68,5 +69,30 @@ class DownloadTablesABSDefaultTest extends DownloadTablesTestAbstract
         self::assertEquals("in.c-docker-test.test2", $manifest["id"]);
         $this->assertABSinfo($manifest);
         self::assertTrue($logger->hasInfoThatContains('Processing 2 ABS table exports.'));
+    }
+
+    public function testReadTablesS3UnsupportedBackend()
+    {
+        $logger = new TestLogger();
+        $reader = new Reader($this->client, $logger, new NullWorkspaceProvider());
+        $configuration = new InputTableOptionsList([
+            [
+                "source" => "in.c-docker-test.test",
+                "destination" => "test.csv",
+            ],
+            [
+                "source" => "in.c-docker-test.test2",
+                "destination" => "test2.csv",
+            ]
+        ]);
+
+        self::expectException(InvalidInputException::class);
+        self::expectExceptionMessage('This project does not have S3 backend.');
+        $reader->downloadTables(
+            $configuration,
+            new InputTableStateList([]),
+            $this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . "download",
+            "s3"
+        );
     }
 }

--- a/Tests/Reader/DownloadTablesDefaultTest.php
+++ b/Tests/Reader/DownloadTablesDefaultTest.php
@@ -344,7 +344,7 @@ class DownloadTablesDefaultTest extends DownloadTablesTestAbstract
         $configuration = new InputTableOptionsList([
             [
                 "source" => "in.c-docker-test.test",
-                "columns" => [
+                "column_types" => [
                      [
                          "source" => "bar",
                          "type" => "NUMERIC",

--- a/Tests/Reader/DownloadTablesS3DefaultTest.php
+++ b/Tests/Reader/DownloadTablesS3DefaultTest.php
@@ -73,4 +73,29 @@ class DownloadTablesS3DefaultTest extends DownloadTablesTestAbstract
         $this->assertS3info($manifest);
         self::assertTrue($logger->hasInfoThatContains('Processing 2 S3 table exports.'));
     }
+
+    public function testReadTablesABSUnsupportedBackend()
+    {
+        $logger = new TestLogger();
+        $reader = new Reader($this->client, $logger, new NullWorkspaceProvider());
+        $configuration = new InputTableOptionsList([
+            [
+                "source" => "in.c-docker-test.test",
+                "destination" => "test.csv",
+            ],
+            [
+                "source" => "in.c-docker-test.test2",
+                "destination" => "test2.csv",
+            ]
+        ]);
+
+        self::expectException(InvalidInputException::class);
+        self::expectExceptionMessage('This project does not have ABS backend.');
+        $reader->downloadTables(
+            $configuration,
+            new InputTableStateList([]),
+            $this->temp->getTmpFolder() . DIRECTORY_SEPARATOR . "download",
+            'abs'
+        );
+    }
 }

--- a/Tests/Reader/DownloadTablesWorkspaceRedshiftTest.php
+++ b/Tests/Reader/DownloadTablesWorkspaceRedshiftTest.php
@@ -25,7 +25,7 @@ class DownloadTablesWorkspaceRedshiftTest extends DownloadTablesWorkspaceTestAbs
             [
                 'source' => 'in.c-input-mapping-test.test2',
                 'destination' => 'test2',
-                'columns' => [
+                'column_types' => [
                     [
                         'source' => 'Id',
                         'type' => 'VARCHAR',

--- a/Tests/Reader/DownloadTablesWorkspaceSnowflakeTest.php
+++ b/Tests/Reader/DownloadTablesWorkspaceSnowflakeTest.php
@@ -135,7 +135,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends DownloadTablesWorkspaceTestAb
                 'destination' => 'test2',
                 'where_column' => 'Id',
                 'where_values' => ['id2', 'id3'],
-                'columns' => [
+                'column_types' => [
                     [
                         'source' => 'Id',
                         'destination' => 'MyId',
@@ -181,7 +181,7 @@ class DownloadTablesWorkspaceSnowflakeTest extends DownloadTablesWorkspaceTestAb
                 'destination' => 'test2',
                 'where_column' => 'Id',
                 'where_values' => ['id2'],
-                'columns' => [
+                'column_types' => [
                     [
                         'source' => 'Id',
                         'destination' => 'MyId',

--- a/Tests/Reader/Options/InputTableOptionsTest.php
+++ b/Tests/Reader/Options/InputTableOptionsTest.php
@@ -186,7 +186,7 @@ class InputTableOptionsTest extends \PHPUnit_Framework_TestCase
     {
         self::expectException(InvalidInputException::class);
         self::expectExceptionMessage(
-            'Both columns and column_types are specified, columns field contains surplus columns: col1.'
+            'Both "columns" and "column_types" are specified, "columns" field contains surplus columns: "col1".'
         );
         new InputTableOptions([
             'source' => 'test',
@@ -210,7 +210,7 @@ class InputTableOptionsTest extends \PHPUnit_Framework_TestCase
     {
         self::expectException(InvalidInputException::class);
         self::expectExceptionMessage(
-            'Both columns and column_types are specified, column_types field contains surplus columns: col2.'
+            'Both "columns" and "column_types" are specified, "column_types" field contains surplus columns: "col2".'
         );
         new InputTableOptions([
             'source' => 'test',

--- a/Tests/Reader/Options/InputTableOptionsTest.php
+++ b/Tests/Reader/Options/InputTableOptionsTest.php
@@ -31,6 +31,7 @@ class InputTableOptionsTest extends \PHPUnit_Framework_TestCase
             'columns' => [],
             'where_values' => [],
             'where_operator' => 'eq',
+            'column_types' => [],
         ], $definition->getDefinition());
     }
 
@@ -42,7 +43,7 @@ class InputTableOptionsTest extends \PHPUnit_Framework_TestCase
 
     public function testGetColumnsExtended()
     {
-        $definition = new InputTableOptions(['source' => 'test', 'columns' => [['source' => 'col1'], ['source' => 'col2']]]);
+        $definition = new InputTableOptions(['source' => 'test', 'column_types' => [['source' => 'col1'], ['source' => 'col2']]]);
         self::assertEquals(['col1', 'col2'], $definition->getColumnNames());
     }
 
@@ -93,7 +94,7 @@ class InputTableOptionsTest extends \PHPUnit_Framework_TestCase
         $definition = new InputTableOptions([
             'source' => 'test',
             'destination' => 'dest',
-            'columns' => [
+            'column_types' => [
                 [
                     'source' => 'col1',
                     'type' => 'VARCHAR',
@@ -146,7 +147,7 @@ class InputTableOptionsTest extends \PHPUnit_Framework_TestCase
         $definition = new InputTableOptions([
             'source' => 'test',
             'destination' => 'dest',
-            'columns' => [
+            'column_types' => [
                 [
                     'source' => 'col1',
                     'type' => 'VARCHAR',
@@ -181,17 +182,45 @@ class InputTableOptionsTest extends \PHPUnit_Framework_TestCase
         ], $definition->getStorageApiLoadOptions(new InputTableStateList([])));
     }
 
-    public function testInvalidColumns()
+    public function testInvalidColumnsMissing()
     {
         self::expectException(InvalidInputException::class);
         self::expectExceptionMessage(
-            'Columns must be either specified as array of strings or as array of objects with type, but not both'
+            'Both columns and column_types are specified, columns field contains surplus columns: col1.'
         );
-        $definition = new InputTableOptions([
+        new InputTableOptions([
             'source' => 'test',
             'destination' => 'dest',
-            'columns' => [
-                'col1',
+            'columns' => ['col2', 'col1'],
+            'column_types' => [
+                [
+                    'source' => 'col2',
+                    'type' => 'VARCHAR',
+                ],
+            ],
+            'changed_since' => '-1 days',
+            'where_column' => 'col1',
+            'where_operator' => 'ne',
+            'where_values' => ['1', '2'],
+            'limit' => 100,
+        ]);
+    }
+
+    public function testInvalidColumnSurplus()
+    {
+        self::expectException(InvalidInputException::class);
+        self::expectExceptionMessage(
+            'Both columns and column_types are specified, column_types field contains surplus columns: col2.'
+        );
+        new InputTableOptions([
+            'source' => 'test',
+            'destination' => 'dest',
+            'columns' => ['col1'],
+            'column_types' => [
+                [
+                    'source' => 'col1',
+                    'type' => 'VARCHAR',
+                ],
                 [
                     'source' => 'col2',
                     'type' => 'VARCHAR',

--- a/Tests/Reader/TableDefinitionResolverTest.php
+++ b/Tests/Reader/TableDefinitionResolverTest.php
@@ -75,6 +75,7 @@ class TableDefinitionResolverTest extends \PHPUnit_Framework_TestCase
             ],
             "destination" => "test",
             'columns' => [],
+            'column_types' => [],
             'where_values' => [],
             'where_operator' => 'eq',
             "source" => "table1",

--- a/Tests/Strategy/LocalStrategyTest.php
+++ b/Tests/Strategy/LocalStrategyTest.php
@@ -84,7 +84,7 @@ class LocalStrategyTest extends PHPUnit_Framework_TestCase
             [
                 'source' => 'in.c-input-mapping-test-strategy.test1',
                 'destination' => 'some-table.csv',
-                'columns' => [
+                'column_types' => [
                     [
                         'source' => 'Id',
                         'destination' => 'myid',

--- a/Tests/Strategy/S3StrategyTest.php
+++ b/Tests/Strategy/S3StrategyTest.php
@@ -84,7 +84,7 @@ class S3StrategyTest extends \PHPUnit_Framework_TestCase
             [
                 'source' => 'in.c-input-mapping-test-strategy.test1',
                 'destination' => 'some-table.csv',
-                'columns' => [
+                'column_types' => [
                     [
                         'source' => 'Id',
                         'destination' => 'myid',


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-717

plus fixnuty bugisek z predchoziho merge https://github.com/keboola/input-mapping/pull/55/commits/698735dd972b08933d86f619941e8f7bf2ff6a99

plus jsem tam pridal kontrolu a test na to, kdyz se spusti komponenta s s3 mappingem na abs backendu a obracene (koncilo to hlaskou undefined index)