### PR TITLE
fix: in case of sliced file, the name is the name of the manifest

### DIFF
--- a/Reader/Strategy/ABSStrategy.php
+++ b/Reader/Strategy/ABSStrategy.php
@@ -50,13 +50,13 @@ class ABSStrategy extends AbstractStrategy
             throw new InvalidInputException('This project does not have ABS backend.');
         }
         return [
-            "is_sliced" => $fileInfo["isSliced"],
-            "region" => $fileInfo["region"],
-            "container" => $fileInfo['absPath']['container'],
-            "name" => $fileInfo['absPath']['name'],
-            "credentials" => [
-                "sas_connection_string" => $fileInfo['absCredentials']['SASConnectionString'],
-                "expiration" => $fileInfo['absCredentials']['expiration'],
+            'is_sliced' => $fileInfo['isSliced'],
+            'region' => $fileInfo['region'],
+            'container' => $fileInfo['absPath']['container'],
+            'name' => $fileInfo['isSliced'] ? $fileInfo['absPath']['name'] . 'manifest' : $fileInfo['absPath']['name'],
+            'credentials' => [
+                'sas_connection_string' => $fileInfo['absCredentials']['SASConnectionString'],
+                'expiration' => $fileInfo['absCredentials']['expiration'],
             ],
         ];
     }

--- a/Tests/Reader/DownloadTablesTestAbstract.php
+++ b/Tests/Reader/DownloadTablesTestAbstract.php
@@ -71,6 +71,10 @@ class DownloadTablesTestAbstract extends \PHPUnit_Framework_TestCase
         self::assertArrayHasKey("credentials", $manifest["abs"]);
         self::assertArrayHasKey("sas_connection_string", $manifest["abs"]['credentials']);
         self::assertArrayHasKey("expiration", $manifest["abs"]['credentials']);
+
+        if ($manifest["abs"]["is_sliced"]) {
+            self::assertStringEndsWith("manifest", $manifest["abs"]["name"]);
+        }
     }
 
     /**


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-924

took us some time to figure out how it should work - added this https://github.com/keboola/developers-docs/pull/138 which hopefully makes it clear

the fact that the snowflake writer relies on naming of the files is irrelevant.
