### PR TITLE
fix preserve workspace

### DIFF
--- a/src/File/Strategy/ABSWorkspace.php
+++ b/src/File/Strategy/ABSWorkspace.php
@@ -29,6 +29,7 @@ class ABSWorkspace extends AbstractStrategy implements StrategyInterface
             $workspaceId = $this->dataStorage->getWorkspaceId();
             $workspaces->loadWorkspaceData($workspaceId, [
                 'input' => $this->inputs,
+                'preserve' => 1,
             ]);
             $this->logger->info('All files were fetched.');
         }


### PR DESCRIPTION
fix: do not clear workspace when loading files, so that tables and files can be loaded into the same ABS workspace
https://keboola.atlassian.net/browse/PS-1653