### PR TITLE
PS-1818 add distribution key config param

### DIFF
--- a/src/Configuration/Table/Manifest.php
+++ b/src/Configuration/Table/Manifest.php
@@ -24,6 +24,7 @@ class Manifest extends Configuration
                 ->scalarNode("name")->end()
                 ->scalarNode("uri")->end()
                 ->arrayNode("primary_key")->prototype("scalar")->end()->end()
+                ->arrayNode("distribution_key")->prototype("scalar")->end()->end()
                 ->scalarNode("created")->end()
                 ->scalarNode("last_import_date")->end()
                 ->scalarNode("last_change_date")->end()

--- a/src/Helper/ManifestCreator.php
+++ b/src/Helper/ManifestCreator.php
@@ -32,6 +32,7 @@ class ManifestCreator
             "uri" => $tableInfo["uri"],
             "name" => $tableInfo["name"],
             "primary_key" => $tableInfo["primaryKey"],
+            "distribution_key" => $tableInfo['distributionKey'],
             "created" => $tableInfo["created"],
             "last_change_date" => $tableInfo["lastChangeDate"],
             "last_import_date" => $tableInfo["lastImportDate"],

--- a/tests/Configuration/Table/TableManifestConfigurationTest.php
+++ b/tests/Configuration/Table/TableManifestConfigurationTest.php
@@ -13,6 +13,7 @@ class TableManifestConfigurationTest extends \PHPUnit_Framework_TestCase
             "uri" => "https://connection.keboola.com//v2/storage/tables/in.c-docker-test.test",
             "name" => "test",
             "primary_key" => ["col1", "col2"],
+            "distribution_key" => ["col1"],
             "created" => "2015-01-23T04:11:18+0100",
             "last_import_date" => "2015-01-23T04:11:18+0100",
             "last_change_date" => "2015-01-23T04:11:18+0100",


### PR DESCRIPTION
Nothing really is required here except the config update.  If the table in storage has a distribution key, the one in the workspace will automatically have the same one.  (ref slack: https://keboola.slack.com/archives/CFVRE56UA/p1615975587003300)