### PR TITLE
PS-2232 Add `use_view` option for table configuration

### DIFF
--- a/src/Configuration/Table.php
+++ b/src/Configuration/Table.php
@@ -68,6 +68,7 @@ class Table extends Configuration
                     ->end()
                 ->end()
                 ->booleanNode("overwrite")->defaultValue(false)->end()
+                ->booleanNode("use_view")->defaultValue(false)->end()
             ->end()
             ->validate()
             ->ifTrue(function ($v) {

--- a/src/Table/Options/InputTableOptions.php
+++ b/src/Table/Options/InputTableOptions.php
@@ -208,4 +208,9 @@ class InputTableOptions
         $exportOptions['overwrite'] = $this->definition['overwrite'];
         return $exportOptions;
     }
+
+    public function isUseView()
+    {
+        return $this->definition['use_view'];
+    }
 }

--- a/src/Table/Strategy/ABSWorkspace.php
+++ b/src/Table/Strategy/ABSWorkspace.php
@@ -24,14 +24,20 @@ class ABSWorkspace extends AbstractStrategy
         foreach ($exports as $export) {
             list ($table, $exportOptions) = $export['table'];
             $destination = $this->getDestinationFilePath($this->ensureNoPathDelimiter($this->destination), $table);
-            $copyInputs[] = array_merge(
+            $copyInput = array_merge(
                 [
                     'source' => $table->getSource(),
                     'destination' => $this->ensureNoPathDelimiter($destination),
                 ],
                 $exportOptions
             );
+
+            if ($table->isUseView()) {
+                $copyInput['useView'] = true;
+            }
+
             $workspaceTables[] = $table;
+            $copyInputs[] = $copyInput;
         }
         $this->logger->info(
             sprintf('Copying %s tables to workspace.', count($copyInputs))

--- a/src/Table/Strategy/Snowflake.php
+++ b/src/Table/Strategy/Snowflake.php
@@ -43,14 +43,20 @@ class Snowflake extends AbstractStrategy
             }
             if ($export['type'] === 'copy') {
                 list ($table, $exportOptions) = $export['table'];
-                $copyInputs[] = array_merge(
+                $copyInput = array_merge(
                     [
                         'source' => $table->getSource(),
-                        'destination' => $table->getDestination(),
+                        'destination' => $table->getDestination()
                     ],
                     $exportOptions
                 );
+
+                if ($table->isUseView()) {
+                    $copyInput['useView'] = true;
+                }
+
                 $workspaceTables[] = $table;
+                $copyInputs[] = $copyInput;
             }
         }
 

--- a/src/Table/Strategy/Synapse.php
+++ b/src/Table/Strategy/Synapse.php
@@ -24,14 +24,20 @@ class Synapse extends AbstractStrategy
         foreach ($exports as $export) {
             /** @var InputTableOptions $table */
             list ($table, $exportOptions) = $export['table'];
-            $copyInputs[] = array_merge(
+            $copyInput = array_merge(
                 [
                     'source' => $table->getSource(),
                     'destination' => $table->getDestination(),
                 ],
                 $exportOptions
             );
+
+            if ($table->isUseView()) {
+                $copyInput['useView'] = true;
+            }
+
             $workspaceTables[] = $table;
+            $copyInputs[] = $copyInput;
         }
         $workspaceJobs = [];
         $this->logger->info(

--- a/tests/Configuration/TableConfigurationTest.php
+++ b/tests/Configuration/TableConfigurationTest.php
@@ -33,6 +33,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_operator" => "ne",
                     "column_types" => [],
                     "overwrite" => false,
+                    "use_view" => false,
                 ],
             ],
             'DaysNullConfiguration' => [
@@ -55,6 +56,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_operator" => "ne",
                     "column_types" => [],
                     "overwrite" => false,
+                    "use_view" => false,
                 ],
             ],
             'DaysConfiguration' => [
@@ -77,6 +79,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_operator" => "ne",
                     "column_types" => [],
                     "overwrite" => false,
+                    "use_view" => false,
                 ],
             ],
             'ChangedSinceNullConfiguration' => [
@@ -99,6 +102,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_operator" => "ne",
                     "column_types" => [],
                     "overwrite" => false,
+                    "use_view" => false,
                 ],
             ],
             'ChangedSinceConfiguration' => [
@@ -121,6 +125,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_operator" => "ne",
                     "column_types" => [],
                     "overwrite" => false,
+                    "use_view" => false,
                 ],
             ],
             'SearchSourceConfiguration' => [
@@ -149,6 +154,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_operator" => "ne",
                     "column_types" => [],
                     "overwrite" => false,
+                    "use_view" => false,
                 ],
             ],
             'DataTypesConfiguration' => [
@@ -187,6 +193,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_values" => ["val1", "val2"],
                     "where_operator" => "ne",
                     "overwrite" => false,
+                    "use_view" => false,
                 ],
             ],
             'FullDataTypesConfiguration' => [
@@ -224,6 +231,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                         ],
                     ],
                     "overwrite" => false,
+                    "use_view" => false,
                 ],
             ],
             'FullDataTypesConfigurationEmptyLength' => [
@@ -261,6 +269,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                         ],
                     ],
                     "overwrite" => false,
+                    "use_view" => false,
                 ],
             ],
             "OverwriteConfiguration" => [
@@ -275,6 +284,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_operator" => "eq",
                     "column_types" => [],
                     "overwrite" => true,
+                    "use_view" => false,
                 ],
             ],
             "BasicConfiguration" => [
@@ -288,6 +298,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
                     "where_operator" => "eq",
                     "column_types" => [],
                     "overwrite" => false,
+                    "use_view" => false,
                 ],
             ],
         ];
@@ -380,6 +391,7 @@ class TableConfigurationTest extends \PHPUnit_Framework_TestCase
         $expectedArray["where_values"] = [];
         $expectedArray["column_types"] = [];
         $expectedArray["overwrite"] = false;
+        $expectedArray["use_view"] = false;
         $processedConfiguration = (new Table())->parse(["config" => $config]);
         self::assertEquals($expectedArray, $processedConfiguration);
     }

--- a/tests/Functional/DownloadTablesWorkspaceAbsTest.php
+++ b/tests/Functional/DownloadTablesWorkspaceAbsTest.php
@@ -9,6 +9,7 @@ use Keboola\InputMapping\State\InputTableStateList;
 use Keboola\InputMapping\Table\Options\InputTableOptionsList;
 use Keboola\InputMapping\Table\Options\ReaderOptions;
 use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Exception;
 use Keboola\StorageApiBranch\ClientWrapper;
 use MicrosoftAzure\Storage\Blob\BlobRestProxy;
@@ -151,5 +152,29 @@ class DownloadTablesWorkspaceAbsTest extends DownloadTablesWorkspaceTestAbstract
         $this->assertBlobs('download/test/test1');
         self::assertTrue($logger->hasInfoThatContains('Using "workspace-abs" table input staging.'));
         self::assertTrue($logger->hasInfoThatContains('Table "in.c-input-mapping-test.test1" will be copied.'));
+    }
+
+    public function testUseViewFails()
+    {
+        $logger = new TestLogger();
+        $reader = new Reader($this->getStagingFactory(null, 'json', $logger, [StrategyFactory::WORKSPACE_ABS, 'abs']));
+        $configuration = new InputTableOptionsList([
+            [
+                'source' => 'in.c-input-mapping-test.test1',
+                'destination' => 'test1',
+                'use_view' => true,
+            ]
+        ]);
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('View load for table "download/test1" using backend "abs" can\'t be used, only Synapse is supported.');
+
+        $reader->downloadTables(
+            $configuration,
+            new InputTableStateList([]),
+            'download',
+            StrategyFactory::WORKSPACE_ABS,
+            new ReaderOptions(true)
+        );
     }
 }

--- a/tests/Functional/DownloadTablesWorkspaceSnowflakeTest.php
+++ b/tests/Functional/DownloadTablesWorkspaceSnowflakeTest.php
@@ -304,4 +304,29 @@ class DownloadTablesWorkspaceSnowflakeTest extends DownloadTablesWorkspaceTestAb
         self::assertTrue($logger->hasInfoThatContains('Cloning 1 tables to workspace.'));
         self::assertTrue($logger->hasInfoThatContains('Processing 1 workspace exports.'));
     }
+
+    public function testUseViewFails()
+    {
+        $logger = new TestLogger();
+        $reader = new Reader($this->getStagingFactory(null, 'json', $logger, [StrategyFactory::WORKSPACE_SNOWFLAKE, 'snowflake']));
+        $configuration = new InputTableOptionsList([
+            [
+                'source' => 'in.c-input-mapping-test.test1',
+                'destination' => 'test1',
+                'limit' => 100,
+                'use_view' => true,
+            ]
+        ]);
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('View load for table "test1" using backend "snowflake" can\'t be used, only Synapse is supported.');
+
+        $reader->downloadTables(
+            $configuration,
+            new InputTableStateList([]),
+            'download',
+            StrategyFactory::WORKSPACE_SNOWFLAKE,
+            new ReaderOptions(true)
+        );
+    }
 }

--- a/tests/Helper/SourceRewriteHelperTest.php
+++ b/tests/Helper/SourceRewriteHelperTest.php
@@ -98,6 +98,7 @@ class SourceRewriteHelperTest extends TestCase
                 'where_values' => [],
                 'where_operator' => 'eq',
                 'overwrite' => false,
+                'use_view' => false,
             ],
             $destinations->getTables()[0]->getDefinition()
         );
@@ -112,6 +113,7 @@ class SourceRewriteHelperTest extends TestCase
                 'where_values' => [],
                 'where_operator' => 'eq',
                 'overwrite' => false,
+                'use_view' => false,
             ],
             $destinations->getTables()[1]->getDefinition()
         );
@@ -173,6 +175,7 @@ class SourceRewriteHelperTest extends TestCase
                 'where_values' => [],
                 'where_operator' => 'eq',
                 'overwrite' => false,
+                'use_view' => false,
             ],
             $destinations->getTables()[0]->getDefinition()
         );
@@ -187,6 +190,7 @@ class SourceRewriteHelperTest extends TestCase
                 'where_values' => [],
                 'where_operator' => 'eq',
                 'overwrite' => false,
+                'use_view' => false,
             ],
             $destinations->getTables()[1]->getDefinition()
         );
@@ -236,6 +240,7 @@ class SourceRewriteHelperTest extends TestCase
                 'where_values' => [],
                 'where_operator' => 'eq',
                 'overwrite' => false,
+                'use_view' => false,
             ],
             $destinations->getTables()[0]->getDefinition()
         );
@@ -251,6 +256,7 @@ class SourceRewriteHelperTest extends TestCase
                 'where_values' => [],
                 'where_operator' => 'eq',
                 'overwrite' => false,
+                'use_view' => false,
             ],
             $destinations->getTables()[1]->getDefinition()
         );

--- a/tests/Table/Options/InputTableOptionsTest.php
+++ b/tests/Table/Options/InputTableOptionsTest.php
@@ -34,6 +34,7 @@ class InputTableOptionsTest extends TestCase
             'where_operator' => 'eq',
             'column_types' => [],
             'overwrite' => false,
+            'use_view' => false,
         ], $definition->getDefinition());
     }
 
@@ -324,5 +325,15 @@ class InputTableOptionsTest extends TestCase
         self::expectExceptionMessage('Days option is not supported on workspace, use changed_since instead.');
         self::expectException(InvalidInputException::class);
         $definition->getStorageApiLoadOptions(new InputTableStateList([]));
+    }
+
+    public function testIsUseView()
+    {
+        $definition = new InputTableOptions([
+            'source' => 'test',
+            'use_view' => true,
+        ]);
+
+        self::assertTrue($definition->isUseView());
     }
 }

--- a/tests/Table/TableDefinitionResolverTest.php
+++ b/tests/Table/TableDefinitionResolverTest.php
@@ -80,6 +80,7 @@ class TableDefinitionResolverTest extends TestCase
             'where_values' => [],
             'where_operator' => 'eq',
             'overwrite' => false,
+            'use_view' => false,
             "source" => "table1",
         ], $result->getTables()[0]->getDefinition());
     }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-2232

* Je to sice experimentalni flag, i tam by ale ais bylo dobry ho pokryt funkcnimi testy, co? K podpore potrebuje projekt mit nastaveny `workspace-view-load` flag. Muzu si ho normalne prihodit k existujicimu CI projektu nebo si ma zalozit novy?
* Implementace na strane API je sice jen pro Synapse, pridal jsem ale i do ostatnich workspace, aby se choval stejne error handling (kdyz ten flag zapnu nekde, kde nema byt, tak vybehne error)