### PR TITLE
Accept case-insensitive load_type in Configuration\Table

### DIFF
--- a/src/Configuration/Table.php
+++ b/src/Configuration/Table.php
@@ -77,6 +77,15 @@ class Table extends Configuration
                 // emitted in the parsed output. No default so it cannot be re-added after being unset.
                 ->booleanNode('use_view')->end()
                 ->enumNode('load_type')
+                    // Accept any case (e.g. "view"/"View"/"VIEW"); callers are not
+                    // consistent about it. Upper-case before the enum check so the
+                    // permissible-values validation and the parsed output stay canonical.
+                    ->beforeNormalization()
+                        ->ifString()
+                        ->then(function ($v) {
+                            return strtoupper($v);
+                        })
+                    ->end()
                     ->values(['COPY', 'CLONE', 'VIEW', 'AUTO'])
                 ->end()
                 ->booleanNode('keep_internal_timestamp_column')->defaultValue(true)->end()

--- a/tests/Configuration/TableConfigurationTest.php
+++ b/tests/Configuration/TableConfigurationTest.php
@@ -453,6 +453,38 @@ class TableConfigurationTest extends TestCase
                     'keep_internal_timestamp_column' => true,
                 ],
             ],
+            'LoadTypeLowerCaseView' => [
+                [
+                    'source' => 'in.c-main.test',
+                    'load_type' => 'view',
+                ],
+                [
+                    'source' => 'in.c-main.test',
+                    'columns' => [],
+                    'where_values' => [],
+                    'where_operator' => 'eq',
+                    'column_types' => [],
+                    'overwrite' => false,
+                    'load_type' => 'VIEW',
+                    'keep_internal_timestamp_column' => true,
+                ],
+            ],
+            'LoadTypeMixedCaseClone' => [
+                [
+                    'source' => 'in.c-main.test',
+                    'load_type' => 'Clone',
+                ],
+                [
+                    'source' => 'in.c-main.test',
+                    'columns' => [],
+                    'where_values' => [],
+                    'where_operator' => 'eq',
+                    'column_types' => [],
+                    'overwrite' => false,
+                    'load_type' => 'CLONE',
+                    'keep_internal_timestamp_column' => true,
+                ],
+            ],
             'LoadTypeAuto' => [
                 [
                     'source' => 'in.c-main.test',


### PR DESCRIPTION
## What

`Configuration\Table`'s `load_type` enumNode rejected lower/mixed-case values. A config with `load_type: "view"` failed parsing with:

```
The value "view" is not allowed for path "table.load_type". Permissible values: "COPY", "CLONE", "VIEW", "AUTO".
```

This happens during config parsing in the editor-service / runner — **before** the request reaches connection's `input-mapping-load` endpoint — so connection's own case-insensitive `load_type` handling never gets a chance.

## Fix

Upper-case the value in a `beforeNormalization` step on the `load_type` enumNode (mirroring the existing `where_operator` node), so `view`/`View`/`VIEW` all normalize to the canonical `VIEW` before the permissible-values check. A genuinely invalid value (e.g. `bogus`) is still rejected.

## Tests

Added `LoadTypeLowerCaseView` (`view` → `VIEW`) and `LoadTypeMixedCaseClone` (`Clone` → `CLONE`) cases to `TableConfigurationTest`.

Verified the Symfony Config behavior with a standalone reproduction (`view`/`View`/`VIEW` → `VIEW`; `bogus` rejected). I could not run the lib's PHPUnit locally — this split clone needs the `platform-libraries` monorepo path repos for `composer install`; CI will run the suite.

## Context

For @odin — the lowercase `load_type` issue from the BigQuery CLONE thread. Targeted at `odin/AJDA-2841-2` since the `input-mapping-load` adoption + `use_view`→`load_type` conversion live there. Pairs with the connection-side leniency already merged (keboola/connection#7614).